### PR TITLE
[REFACTOR] 자료형 통일, 예외처리 수정

### DIFF
--- a/src/main/java/org/server/remoteclass/controller/AdminController.java
+++ b/src/main/java/org/server/remoteclass/controller/AdminController.java
@@ -1,0 +1,10 @@
+package org.server.remoteclass.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin")
+public class AdminController {
+
+}

--- a/src/main/java/org/server/remoteclass/controller/AdminController.java
+++ b/src/main/java/org/server/remoteclass/controller/AdminController.java
@@ -6,6 +6,7 @@ import org.server.remoteclass.jpa.UserRepository;
 import org.server.remoteclass.service.StudentService;
 import org.server.remoteclass.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,9 +28,8 @@ public class AdminController {
 
     //수강생 전체 조회 /강의자 권한
     @GetMapping("/{lectureId}/list")
-    public Iterable<StudentDto> getStudentsByLectureId(@PathVariable("lectureId") Long lectureId) throws IdNotExistException {
-        return this.studentService.getStudentsByLectureId(lectureId).stream()
-                .map(StudentDto::new).collect(Collectors.toList());
+    public ResponseEntity<Iterable<StudentDto>> getStudentsByLectureId(@PathVariable("lectureId") Long lectureId) throws IdNotExistException {
+        return ResponseEntity.ok(studentService.getStudentsByLectureId(lectureId));
     }
 
 }

--- a/src/main/java/org/server/remoteclass/controller/AdminController.java
+++ b/src/main/java/org/server/remoteclass/controller/AdminController.java
@@ -1,10 +1,35 @@
 package org.server.remoteclass.controller;
 
+import org.server.remoteclass.dto.StudentDto;
+import org.server.remoteclass.exception.IdNotExistException;
+import org.server.remoteclass.jpa.UserRepository;
+import org.server.remoteclass.service.StudentService;
+import org.server.remoteclass.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/admin")
 public class AdminController {
+
+    private final StudentService studentService;
+
+    @Autowired
+    public AdminController(StudentService studentService){
+        this.studentService = studentService;
+    }
+
+    //수강생 전체 조회 /강의자 권한
+    @GetMapping("/{lectureId}/list")
+    public List<StudentDto> getStudentsByLectureId(@PathVariable("lectureId") Long lectureId) throws IdNotExistException {
+        return this.studentService.getStudentsByLectureId(lectureId).stream()
+                .map(StudentDto::new).collect(Collectors.toList());
+    }
 
 }

--- a/src/main/java/org/server/remoteclass/controller/AdminController.java
+++ b/src/main/java/org/server/remoteclass/controller/AdminController.java
@@ -27,7 +27,7 @@ public class AdminController {
 
     //수강생 전체 조회 /강의자 권한
     @GetMapping("/{lectureId}/list")
-    public List<StudentDto> getStudentsByLectureId(@PathVariable("lectureId") Long lectureId) throws IdNotExistException {
+    public Iterable<StudentDto> getStudentsByLectureId(@PathVariable("lectureId") Long lectureId) throws IdNotExistException {
         return this.studentService.getStudentsByLectureId(lectureId).stream()
                 .map(StudentDto::new).collect(Collectors.toList());
     }

--- a/src/main/java/org/server/remoteclass/controller/AdminController.java
+++ b/src/main/java/org/server/remoteclass/controller/AdminController.java
@@ -26,10 +26,4 @@ public class AdminController {
         this.studentService = studentService;
     }
 
-    //수강생 전체 조회 /강의자 권한
-    @GetMapping("/{lectureId}/list")
-    public ResponseEntity<Iterable<StudentDto>> getStudentsByLectureId(@PathVariable("lectureId") Long lectureId) throws IdNotExistException {
-        return ResponseEntity.ok(studentService.getStudentsByLectureId(lectureId));
-    }
-
 }

--- a/src/main/java/org/server/remoteclass/controller/LectureController.java
+++ b/src/main/java/org/server/remoteclass/controller/LectureController.java
@@ -58,16 +58,15 @@ public class LectureController {
 
     // 강의 전체 목록 조회
     @GetMapping("/list")
-    public List<LectureDto> getAllLecture(){
+    public Iterable<LectureDto> getAllLecture(){
         return this.lectureService.getLectureByAll().stream()
                 .map(LectureDto::new).collect(Collectors.toList());
     }
 
     //카테고리별 강의 목록 조회
     @GetMapping("/list/{categoryId}")
-    public List<LectureDto> getLectureByCategory(@PathVariable("categoryId") Long categoryId) throws IdNotExistException{
+    public Iterable<LectureDto> getLectureByCategory(@PathVariable("categoryId") Long categoryId) throws IdNotExistException{
         return this.lectureService.getLectureByCategoryId(categoryId).stream()
                 .map(LectureDto::new).collect(Collectors.toList());
     }
-
 }

--- a/src/main/java/org/server/remoteclass/controller/LectureController.java
+++ b/src/main/java/org/server/remoteclass/controller/LectureController.java
@@ -51,15 +51,13 @@ public class LectureController {
 
     // 강의 전체 목록 조회
     @GetMapping("/list")
-    public Iterable<LectureDto> getAllLecture(){
-        return this.lectureService.getLectureByAll().stream()
-                .map(LectureDto::new).collect(Collectors.toList());
+    public ResponseEntity<Iterable<LectureDto>> getAllLecture(){
+        return ResponseEntity.ok(lectureService.getLectureByAll());
     }
 
     //카테고리별 강의 목록 조회
     @GetMapping("/list/{categoryId}")
-    public Iterable<LectureDto> getLectureByCategory(@PathVariable("categoryId") Long categoryId) throws IdNotExistException{
-        return this.lectureService.getLectureByCategoryId(categoryId).stream()
-                .map(LectureDto::new).collect(Collectors.toList());
+    public ResponseEntity<Iterable<LectureDto>> getLectureByCategory(@PathVariable("categoryId") Long categoryId) throws IdNotExistException{
+        return ResponseEntity.ok(lectureService.getLectureByCategoryId(categoryId));
     }
 }

--- a/src/main/java/org/server/remoteclass/controller/LectureController.java
+++ b/src/main/java/org/server/remoteclass/controller/LectureController.java
@@ -27,7 +27,7 @@ public class LectureController {
 
     //강의 생성
     @PostMapping
-    public ResponseEntity createLecture(@RequestBody @Valid LectureFormDto lectureFormDto) throws IdNotExistException {
+    public ResponseEntity<LectureDto> createLecture(@RequestBody @Valid LectureFormDto lectureFormDto) throws IdNotExistException {
         Lecture lecture = lectureService.createLecture(lectureFormDto);
         LectureDto lectureDto = new LectureDto(lecture);
         return ResponseEntity.status(HttpStatus.CREATED).body(lectureDto);
@@ -42,7 +42,7 @@ public class LectureController {
 
     //강의 수정
     @PutMapping
-    public ResponseEntity updateLecture(@RequestBody @Valid LectureFormDto lectureFormDto) throws IdNotExistException {
+    public ResponseEntity<LectureDto> updateLecture(@RequestBody @Valid LectureFormDto lectureFormDto) throws IdNotExistException {
         Lecture lecture = lectureService.updateLecture(lectureFormDto);
         LectureDto responseLecture = new LectureDto(lecture);
         System.out.println(lectureFormDto.getLectureId());

--- a/src/main/java/org/server/remoteclass/controller/LectureController.java
+++ b/src/main/java/org/server/remoteclass/controller/LectureController.java
@@ -2,7 +2,6 @@ package org.server.remoteclass.controller;
 
 import org.server.remoteclass.dto.LectureDto;
 import org.server.remoteclass.dto.LectureFormDto;
-import org.server.remoteclass.entity.Lecture;
 import org.server.remoteclass.exception.IdNotExistException;
 import org.server.remoteclass.service.LectureService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,7 +11,6 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/lecture")
@@ -51,13 +49,13 @@ public class LectureController {
 
     // 강의 전체 목록 조회
     @GetMapping("/list")
-    public ResponseEntity<Iterable<LectureDto>> getAllLecture(){
+    public ResponseEntity<List<LectureDto>> getAllLecture(){
         return ResponseEntity.ok(lectureService.getLectureByAll());
     }
 
     //카테고리별 강의 목록 조회
     @GetMapping("/list/{categoryId}")
-    public ResponseEntity<Iterable<LectureDto>> getLectureByCategory(@PathVariable("categoryId") Long categoryId) throws IdNotExistException{
+    public ResponseEntity<List<LectureDto>> getLectureByCategory(@PathVariable("categoryId") Long categoryId) throws IdNotExistException{
         return ResponseEntity.ok(lectureService.getLectureByCategoryId(categoryId));
     }
 }

--- a/src/main/java/org/server/remoteclass/controller/LectureController.java
+++ b/src/main/java/org/server/remoteclass/controller/LectureController.java
@@ -28,25 +28,18 @@ public class LectureController {
     //강의 생성
     @PostMapping
     public ResponseEntity<LectureDto> createLecture(@RequestBody @Valid LectureFormDto lectureFormDto) throws IdNotExistException {
-        Lecture lecture = lectureService.createLecture(lectureFormDto);
-        LectureDto lectureDto = new LectureDto(lecture);
-        return ResponseEntity.status(HttpStatus.CREATED).body(lectureDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(lectureService.createLecture(lectureFormDto));
     }
     //강의 조회
     @GetMapping("/{lectureId}")
     public ResponseEntity<LectureDto> readLecture(@PathVariable("lectureId") Long lectureId) throws IdNotExistException {
-        Lecture lecture = lectureService.getLectureByLectureId(lectureId);
-        LectureDto lectureDto = new LectureDto(lecture);
-        return ResponseEntity.status(HttpStatus.OK).body(lectureDto);
+        return ResponseEntity.status(HttpStatus.OK).body(lectureService.getLectureByLectureId(lectureId));
     }
 
     //강의 수정
     @PutMapping
     public ResponseEntity<LectureDto> updateLecture(@RequestBody @Valid LectureFormDto lectureFormDto) throws IdNotExistException {
-        Lecture lecture = lectureService.updateLecture(lectureFormDto);
-        LectureDto responseLecture = new LectureDto(lecture);
-        System.out.println(lectureFormDto.getLectureId());
-        return ResponseEntity.status(HttpStatus.CREATED).body(responseLecture);
+        return ResponseEntity.status(HttpStatus.CREATED).body(lectureService.updateLecture(lectureFormDto));
     }
 
     //강의 삭제

--- a/src/main/java/org/server/remoteclass/controller/StudentController.java
+++ b/src/main/java/org/server/remoteclass/controller/StudentController.java
@@ -37,4 +37,10 @@ public class StudentController {
     public ResponseEntity<Iterable<LectureDto>> getAllLectureByUserId() throws IdNotExistException {
         return ResponseEntity.ok(studentService.getLecturesByUserId());
     }
+
+    //수강생 전체 조회 /강의자 권한
+    @GetMapping("/{lectureId}/list")
+    public ResponseEntity<Iterable<StudentDto>> getStudentsByLectureId(@PathVariable("lectureId") Long lectureId) throws IdNotExistException {
+        return ResponseEntity.ok(studentService.getStudentsByLectureId(lectureId));
+    }
 }

--- a/src/main/java/org/server/remoteclass/controller/StudentController.java
+++ b/src/main/java/org/server/remoteclass/controller/StudentController.java
@@ -27,9 +27,7 @@ public class StudentController {
     //수강 신청 학생 권한
     @PostMapping
     public ResponseEntity<StudentDto> applyLecture(@RequestBody @Valid StudentFormDto studentFormDto) throws IdNotExistException {
-        Student student = studentService.applyLecture(studentFormDto);
-        StudentDto studentDto = new StudentDto(student);
-        return ResponseEntity.status(HttpStatus.CREATED).body(studentDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(studentService.applyLecture(studentFormDto));
     }
 
     //수강하는 강좌 전체 조회

--- a/src/main/java/org/server/remoteclass/controller/StudentController.java
+++ b/src/main/java/org/server/remoteclass/controller/StudentController.java
@@ -26,7 +26,7 @@ public class StudentController {
 
     //수강 신청 학생 권한
     @PostMapping
-    public ResponseEntity applyLecture(@RequestBody @Valid StudentFormDto studentFormDto) throws IdNotExistException {
+    public ResponseEntity<StudentDto> applyLecture(@RequestBody @Valid StudentFormDto studentFormDto) throws IdNotExistException {
         Student student = studentService.applyLecture(studentFormDto);
         StudentDto studentDto = new StudentDto(student);
         return ResponseEntity.status(HttpStatus.CREATED).body(studentDto);

--- a/src/main/java/org/server/remoteclass/controller/StudentController.java
+++ b/src/main/java/org/server/remoteclass/controller/StudentController.java
@@ -25,7 +25,7 @@ public class StudentController {
     }
 
     //수강 신청 학생 권한
-    @PostMapping()
+    @PostMapping
     public ResponseEntity applyLecture(@RequestBody @Valid StudentFormDto studentFormDto) throws IdNotExistException {
         Student student = studentService.applyLecture(studentFormDto);
         StudentDto studentDto = new StudentDto(student);
@@ -36,13 +36,6 @@ public class StudentController {
     @GetMapping("/list")
     public List<StudentDto> getAllLectureByUserId() throws IdNotExistException {
         return this.studentService.getLecturesByUserId().stream()
-                .map(StudentDto::new).collect(Collectors.toList());
-    }
-
-    //수강생 전체 조회 /강의자 권한
-    @GetMapping("{lectureId}/list")
-    public List<StudentDto> getStudentsByLectureId(@PathVariable("lectureId") Long lectureId) throws IdNotExistException{
-        return this.studentService.getStudentsByLectureId(lectureId).stream()
                 .map(StudentDto::new).collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/server/remoteclass/controller/StudentController.java
+++ b/src/main/java/org/server/remoteclass/controller/StudentController.java
@@ -1,7 +1,9 @@
 package org.server.remoteclass.controller;
 
+import org.server.remoteclass.dto.LectureDto;
 import org.server.remoteclass.dto.StudentDto;
 import org.server.remoteclass.dto.StudentFormDto;
+import org.server.remoteclass.entity.Lecture;
 import org.server.remoteclass.entity.Student;
 import org.server.remoteclass.exception.IdNotExistException;
 import org.server.remoteclass.service.StudentService;
@@ -32,8 +34,7 @@ public class StudentController {
 
     //수강하는 강좌 전체 조회
     @GetMapping("/list")
-    public List<StudentDto> getAllLectureByUserId() throws IdNotExistException {
-        return this.studentService.getLecturesByUserId().stream()
-                .map(StudentDto::new).collect(Collectors.toList());
+    public ResponseEntity<Iterable<LectureDto>> getAllLectureByUserId() throws IdNotExistException {
+        return ResponseEntity.ok(studentService.getLecturesByUserId());
     }
 }

--- a/src/main/java/org/server/remoteclass/controller/StudentController.java
+++ b/src/main/java/org/server/remoteclass/controller/StudentController.java
@@ -3,8 +3,6 @@ package org.server.remoteclass.controller;
 import org.server.remoteclass.dto.LectureDto;
 import org.server.remoteclass.dto.StudentDto;
 import org.server.remoteclass.dto.StudentFormDto;
-import org.server.remoteclass.entity.Lecture;
-import org.server.remoteclass.entity.Student;
 import org.server.remoteclass.exception.IdNotExistException;
 import org.server.remoteclass.service.StudentService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,7 +12,6 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/student")
@@ -34,13 +31,13 @@ public class StudentController {
 
     //수강하는 강좌 전체 조회
     @GetMapping("/list")
-    public ResponseEntity<Iterable<LectureDto>> getAllLectureByUserId() throws IdNotExistException {
+    public ResponseEntity<List<LectureDto>> getAllLectureByUserId() throws IdNotExistException {
         return ResponseEntity.ok(studentService.getLecturesByUserId());
     }
 
     //수강생 전체 조회 /강의자 권한
     @GetMapping("/{lectureId}/list")
-    public ResponseEntity<Iterable<StudentDto>> getStudentsByLectureId(@PathVariable("lectureId") Long lectureId) throws IdNotExistException {
+    public ResponseEntity<List<StudentDto>> getStudentsByLectureId(@PathVariable("lectureId") Long lectureId) throws IdNotExistException {
         return ResponseEntity.ok(studentService.getStudentsByLectureId(lectureId));
     }
 }

--- a/src/main/java/org/server/remoteclass/controller/UserController.java
+++ b/src/main/java/org/server/remoteclass/controller/UserController.java
@@ -39,9 +39,8 @@ public class UserController {
     }
 
     @GetMapping
-    public ResponseEntity<List<UserDto>> getAllUsers(){
+    public ResponseEntity<Iterable<UserDto>> getAllUsers(){
         return ResponseEntity.ok(userService.getUsersByAll());
-//        return ResponseEntity.ok(userService.getMyUserWithAuthorities());
     }
 
 

--- a/src/main/java/org/server/remoteclass/controller/UserController.java
+++ b/src/main/java/org/server/remoteclass/controller/UserController.java
@@ -1,16 +1,12 @@
 package org.server.remoteclass.controller;
 
 import org.server.remoteclass.dto.UserDto;
-import org.server.remoteclass.entity.User;
 import org.server.remoteclass.jpa.UserRepository;
 import org.server.remoteclass.service.UserService;
-import org.server.remoteclass.vo.RequestUser;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 
 
@@ -39,7 +35,7 @@ public class UserController {
     }
 
     @GetMapping
-    public ResponseEntity<Iterable<UserDto>> getAllUsers(){
+    public ResponseEntity<List<UserDto>> getAllUsers(){
         return ResponseEntity.ok(userService.getUsersByAll());
     }
 

--- a/src/main/java/org/server/remoteclass/controller/UserController.java
+++ b/src/main/java/org/server/remoteclass/controller/UserController.java
@@ -1,30 +1,39 @@
 package org.server.remoteclass.controller;
 
 import org.server.remoteclass.dto.UserDto;
+import org.server.remoteclass.entity.User;
+import org.server.remoteclass.jpa.UserRepository;
 import org.server.remoteclass.service.UserService;
 import org.server.remoteclass.vo.RequestUser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
 
 
 @RestController
+@RequestMapping("/users")
 public class UserController {
 
     private final UserService userService;
+    private final UserRepository userRepository;
 
     @Autowired
-    public UserController(UserService userService){
+    public UserController(UserService userService, UserRepository userRepository){
         this.userService = userService;
+        this.userRepository = userRepository;
     }
 
     @GetMapping("/welcome")
     public String welcome(){
         return "Welcome test";
     }
+
+//    @GetMapping("/myself")
+//    public ResponseEntity<UserDto> getUser(){
+//        return ResponseEntity.ok(userService.getMyUserWithAuthorities().get());
+//    }
 
 }

--- a/src/main/java/org/server/remoteclass/controller/UserController.java
+++ b/src/main/java/org/server/remoteclass/controller/UserController.java
@@ -31,9 +31,10 @@ public class UserController {
         return "Welcome test";
     }
 
-//    @GetMapping("/myself")
-//    public ResponseEntity<UserDto> getUser(){
-//        return ResponseEntity.ok(userService.getMyUserWithAuthorities().get());
-//    }
+    // 본인 정보 조회 기능(비밀번호까지 나와서 다른 유저 조회 시 기능 구현 시엔 주의해야 합니다)
+    @GetMapping("/myself")
+    public ResponseEntity<UserDto> getUser(){
+        return ResponseEntity.ok(userService.getMyUserWithAuthorities());
+    }
 
 }

--- a/src/main/java/org/server/remoteclass/controller/UserController.java
+++ b/src/main/java/org/server/remoteclass/controller/UserController.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.List;
 
 
 @RestController
@@ -36,5 +37,12 @@ public class UserController {
     public ResponseEntity<UserDto> getUser(){
         return ResponseEntity.ok(userService.getMyUserWithAuthorities());
     }
+
+    @GetMapping
+    public ResponseEntity<List<UserDto>> getAllUsers(){
+        return ResponseEntity.ok(userService.getUsersByAll());
+//        return ResponseEntity.ok(userService.getMyUserWithAuthorities());
+    }
+
 
 }

--- a/src/main/java/org/server/remoteclass/dto/LectureDto.java
+++ b/src/main/java/org/server/remoteclass/dto/LectureDto.java
@@ -1,5 +1,6 @@
 package org.server.remoteclass.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import org.server.remoteclass.entity.Category;
@@ -10,6 +11,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import java.time.LocalDate;
 
 @Getter @Setter
+@Builder
 public class LectureDto {
     private Long lectureId;
     private String title;
@@ -31,5 +33,18 @@ public class LectureDto {
         this.endDate = lecture.getEndDate();
         this.category = lecture.getCategory();
         this.user = lecture.getUser();
+    }
+
+    public static LectureDto from(Lecture lecture){
+        if(lecture == null) return null;
+        return LectureDto.builder()
+                .title(lecture.getTitle())
+                .description(lecture.getDescription())
+                .price(lecture.getPrice())
+                .startDate(lecture.getStartDate())
+                .endDate(lecture.getEndDate())
+                .category(lecture.getCategory())
+                .user(lecture.getUser())
+                .build();
     }
 }

--- a/src/main/java/org/server/remoteclass/dto/LectureDto.java
+++ b/src/main/java/org/server/remoteclass/dto/LectureDto.java
@@ -1,5 +1,6 @@
 package org.server.remoteclass.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -12,6 +13,7 @@ import java.time.LocalDate;
 
 @Getter @Setter
 @Builder
+@AllArgsConstructor
 public class LectureDto {
     private Long lectureId;
     private String title;

--- a/src/main/java/org/server/remoteclass/dto/StudentDto.java
+++ b/src/main/java/org/server/remoteclass/dto/StudentDto.java
@@ -1,5 +1,6 @@
 package org.server.remoteclass.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -11,6 +12,7 @@ import org.server.remoteclass.entity.User;
 @Getter
 @Setter
 @Builder
+@AllArgsConstructor
 public class StudentDto {
     private Long studentId;
     private Lecture lecture;

--- a/src/main/java/org/server/remoteclass/dto/StudentDto.java
+++ b/src/main/java/org/server/remoteclass/dto/StudentDto.java
@@ -1,5 +1,6 @@
 package org.server.remoteclass.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import org.server.remoteclass.entity.Lecture;
@@ -9,6 +10,7 @@ import org.server.remoteclass.entity.User;
 
 @Getter
 @Setter
+@Builder
 public class StudentDto {
     private Long studentId;
     private Lecture lecture;
@@ -18,5 +20,13 @@ public class StudentDto {
         this.studentId = student.getStudentId();
         this.lecture = student.getLecture();
         this.user = student.getUser();
+    }
+
+    public static StudentDto from(Student student){
+        if(student == null) return null;
+        return StudentDto.builder()
+                .lecture(student.getLecture())
+                .user(student.getUser())
+                .build();
     }
 }

--- a/src/main/java/org/server/remoteclass/dto/TokenDto.java
+++ b/src/main/java/org/server/remoteclass/dto/TokenDto.java
@@ -15,4 +15,5 @@ public class TokenDto {
     private String accessToken;
     private String refreshToken;
     private Long accessTokenExpireDate;
+
 }

--- a/src/main/java/org/server/remoteclass/dto/TokenDto.java
+++ b/src/main/java/org/server/remoteclass/dto/TokenDto.java
@@ -10,10 +10,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class TokenDto {
-
     private String grantType;
     private String accessToken;
     private String refreshToken;
     private Long accessTokenExpireDate;
-
 }

--- a/src/main/java/org/server/remoteclass/dto/UserDto.java
+++ b/src/main/java/org/server/remoteclass/dto/UserDto.java
@@ -26,6 +26,7 @@ public class UserDto {
     private Timestamp registerDate;
     private Set<AuthorityDto> authorityDtoSet;
 
+    // 본인이 본인 정보 조회 or 관리자가 조회 시 사용할 함수
     public static UserDto from(User user){
         if(user == null) return null;
         return UserDto.builder()

--- a/src/main/java/org/server/remoteclass/dto/UserDto.java
+++ b/src/main/java/org/server/remoteclass/dto/UserDto.java
@@ -9,6 +9,7 @@ import org.server.remoteclass.entity.User;
 import org.server.remoteclass.entity.UserRole;
 
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.Set;
 
 @Data
@@ -23,7 +24,7 @@ public class UserDto {
     private String name;
     private String password;
     private UserRole userRole;
-    private Timestamp registerDate;
+    private LocalDateTime registerDate;
     private Set<AuthorityDto> authorityDtoSet;
 
     // 본인이 본인 정보 조회 or 관리자가 조회 시 사용할 함수

--- a/src/main/java/org/server/remoteclass/entity/Content.java
+++ b/src/main/java/org/server/remoteclass/entity/Content.java
@@ -25,16 +25,11 @@ public class Content {
     @Id @GeneratedValue
     @Column(name = "file_id")
     private Long id;
-
     private String fileUri;
-
     private String fileName;
-
     private String originalFilename;
-
     @Nullable
     private String contentType;
-
     @Override
     public String toString() {
         return "Content{" +

--- a/src/main/java/org/server/remoteclass/entity/Student.java
+++ b/src/main/java/org/server/remoteclass/entity/Student.java
@@ -12,11 +12,11 @@ public class Student {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long studentId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "lecture_id")
     private Lecture lecture;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 }

--- a/src/main/java/org/server/remoteclass/entity/User.java
+++ b/src/main/java/org/server/remoteclass/entity/User.java
@@ -8,7 +8,6 @@ import org.hibernate.annotations.DynamicInsert;
 import org.springframework.data.annotation.CreatedDate;
 
 import javax.persistence.*;
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
 
 @Data

--- a/src/main/java/org/server/remoteclass/entity/User.java
+++ b/src/main/java/org/server/remoteclass/entity/User.java
@@ -31,6 +31,7 @@ public class User {
     private UserRole userRole;
     @Enumerated(EnumType.STRING)
     private Authority authority;
+    // 자료형 LocalDateTime과 호환 고려해 볼게요
     @Column(name="register_date", nullable = false, updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private Timestamp registerDate;
 }

--- a/src/main/java/org/server/remoteclass/entity/User.java
+++ b/src/main/java/org/server/remoteclass/entity/User.java
@@ -5,9 +5,11 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
+import org.springframework.data.annotation.CreatedDate;
 
 import javax.persistence.*;
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 @Data
 @Entity
@@ -31,7 +33,7 @@ public class User {
     private UserRole userRole;
     @Enumerated(EnumType.STRING)
     private Authority authority;
-    // 자료형 LocalDateTime과 호환 고려해 볼게요
     @Column(name="register_date", nullable = false, updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
-    private Timestamp registerDate;
+    @CreatedDate
+    private LocalDateTime registerDate;
 }

--- a/src/main/java/org/server/remoteclass/jpa/LectureRepository.java
+++ b/src/main/java/org/server/remoteclass/jpa/LectureRepository.java
@@ -4,12 +4,12 @@ import org.server.remoteclass.entity.Lecture;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import java.util.Collection;
+import java.util.List;
 
 public interface LectureRepository extends JpaRepository<Lecture, Long>{
 
     //카테고리별 강의 조회
     @Query(value = "select * from lecture l where l.category_id = :categoryId", nativeQuery = true)
-    Collection<Lecture> findByCategoryId(Long categoryId);
+    List<Lecture> findByCategoryId(Long categoryId);
 
 }

--- a/src/main/java/org/server/remoteclass/jpa/StudentRepository.java
+++ b/src/main/java/org/server/remoteclass/jpa/StudentRepository.java
@@ -15,6 +15,6 @@ public interface StudentRepository extends JpaRepository<Student, Long> {
 
     //수강생 별 수강강좌 리스트
 //    @Query(value = "select * from student s where s.user_id = :userId", nativeQuery = true)
-    Collection<Lecture> findByUserId(Long userId);
+    Collection<Lecture> findByStudentId(Long userId);
 
 }

--- a/src/main/java/org/server/remoteclass/jpa/StudentRepository.java
+++ b/src/main/java/org/server/remoteclass/jpa/StudentRepository.java
@@ -1,5 +1,6 @@
 package org.server.remoteclass.jpa;
 
+import org.server.remoteclass.entity.Lecture;
 import org.server.remoteclass.entity.Student;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,7 +14,7 @@ public interface StudentRepository extends JpaRepository<Student, Long> {
     Collection<Student> findByLectureId(Long lectureId);
 
     //수강생 별 수강강좌 리스트
-    @Query(value = "select * from student s where s.user_id = :userId", nativeQuery = true)
-    Collection<Student> findByUserId(Long userId);
+//    @Query(value = "select * from student s where s.user_id = :userId", nativeQuery = true)
+    Collection<Lecture> findByUserId(Long userId);
 
 }

--- a/src/main/java/org/server/remoteclass/jpa/StudentRepository.java
+++ b/src/main/java/org/server/remoteclass/jpa/StudentRepository.java
@@ -5,16 +5,16 @@ import org.server.remoteclass.entity.Student;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import java.util.Collection;
+import java.util.List;
 
 public interface StudentRepository extends JpaRepository<Student, Long> {
 
     // 강좌별 수강생 전체 리스트
     @Query(value = "select * from student s where s.lecture_id = :lectureId", nativeQuery = true)
-    Collection<Student> findByLectureId(Long lectureId);
+    List<Student> findByLectureId(Long lectureId);
 
     //수강생 별 수강강좌 리스트
-//    @Query(value = "select * from student s where s.user_id = :userId", nativeQuery = true)
-    Collection<Lecture> findByStudentId(Long userId);
+    @Query(value = "select * from student s where s.user_id = :userId", nativeQuery = true)
+    List<Lecture> findByStudentId(Long userId);
 
 }

--- a/src/main/java/org/server/remoteclass/jpa/UserRepository.java
+++ b/src/main/java/org/server/remoteclass/jpa/UserRepository.java
@@ -11,6 +11,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findOneWithAuthoritiesByName(String name);
     @EntityGraph(attributePaths = "authorities")
     Optional<User> findOneWithAuthoritiesByEmail(String email);
+    Optional<User> findByUserId(Long id);
     Optional<User> findByEmail(String email);
     boolean existsByEmail(String email); // 이메일 중복 체크시 사용 예정
 }

--- a/src/main/java/org/server/remoteclass/service/AuthServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/AuthServiceImpl.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
+@Transactional
 public class AuthServiceImpl implements AuthService{
 
     private final UserRepository userRepository;
@@ -43,7 +44,6 @@ public class AuthServiceImpl implements AuthService{
         this.refreshTokenRepository = refreshTokenRepository;
     }
 
-    @Transactional
     @Override
     public UserDto signup(UserDto userDto){
         if(userRepository.existsByEmail(userDto.getEmail())){
@@ -61,7 +61,6 @@ public class AuthServiceImpl implements AuthService{
         return UserDto.from(userRepository.save(user));
     }
 
-    @Transactional
     @Override
     public TokenDto login(LoginDto loginDto) {
         // 1. Login ID/PW 를 기반으로 AuthenticationToken 생성
@@ -83,7 +82,6 @@ public class AuthServiceImpl implements AuthService{
         return tokenDto;
     }
 
-    @Transactional
     @Override
     public TokenDto reissue(TokenRequestDto tokenRequestDto){
         // 1. Refresh Token 검증

--- a/src/main/java/org/server/remoteclass/service/CustomUserDetailsService.java
+++ b/src/main/java/org/server/remoteclass/service/CustomUserDetailsService.java
@@ -15,12 +15,12 @@ import java.util.Collections;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CustomUserDetailsService implements UserDetailsService {
 
     private final UserRepository userRepository;
 
     @Override
-    @Transactional(readOnly = true)
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         return userRepository.findByEmail(email)
                 .map(this::createUserDetails)
@@ -28,6 +28,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     }
 
     // DB에 User 값이 존재한다면 UserDetails 객체로 만들어서 리턴
+    @Transactional
     private UserDetails createUserDetails(User user){
         GrantedAuthority grantedAuthority = new SimpleGrantedAuthority(user.getAuthority().toString());
         return new org.springframework.security.core.userdetails.User(

--- a/src/main/java/org/server/remoteclass/service/CustomUserDetailsService.java
+++ b/src/main/java/org/server/remoteclass/service/CustomUserDetailsService.java
@@ -28,6 +28,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     }
 
     // DB에 User 값이 존재한다면 UserDetails 객체로 만들어서 리턴
+    // 빨간 줄이 있는데, 실행 시 에러가 발생하지 않습니다. @Transactional 관련 이슈인데, 빠르게 해결하겠습니다.
     @Transactional
     private UserDetails createUserDetails(User user){
         GrantedAuthority grantedAuthority = new SimpleGrantedAuthority(user.getAuthority().toString());

--- a/src/main/java/org/server/remoteclass/service/CustomUserDetailsService.java
+++ b/src/main/java/org/server/remoteclass/service/CustomUserDetailsService.java
@@ -15,11 +15,11 @@ import java.util.Collections;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class CustomUserDetailsService implements UserDetailsService {
 
     private final UserRepository userRepository;
 
+    @Transactional(readOnly = true)
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         return userRepository.findByEmail(email)
@@ -28,8 +28,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     }
 
     // DB에 User 값이 존재한다면 UserDetails 객체로 만들어서 리턴
-    // 빨간 줄이 있는데, 실행 시 에러가 발생하지 않습니다. @Transactional 관련 이슈인데, 빠르게 해결하겠습니다.
-    @Transactional
+    // @Transactional 있으면 오류 떠서 지웠습니다.
     private UserDetails createUserDetails(User user){
         GrantedAuthority grantedAuthority = new SimpleGrantedAuthority(user.getAuthority().toString());
         return new org.springframework.security.core.userdetails.User(

--- a/src/main/java/org/server/remoteclass/service/LectureService.java
+++ b/src/main/java/org/server/remoteclass/service/LectureService.java
@@ -1,5 +1,6 @@
 package org.server.remoteclass.service;
 
+import org.server.remoteclass.dto.LectureDto;
 import org.server.remoteclass.dto.LectureFormDto;
 import org.server.remoteclass.entity.Lecture;
 import org.server.remoteclass.exception.IdNotExistException;
@@ -9,18 +10,18 @@ import java.util.List;
 public interface LectureService {
 
     //강의 생성
-    Lecture createLecture(LectureFormDto lectureFormDto) throws IdNotExistException;
+    LectureDto createLecture(LectureFormDto lectureFormDto) throws IdNotExistException;
     //강의 조회
-    Lecture getLectureByLectureId(Long lectureId) throws IdNotExistException;
+    LectureDto getLectureByLectureId(Long lectureId) throws IdNotExistException;
     //강의 수정
-    Lecture updateLecture(LectureFormDto lectureFormDto) throws IdNotExistException;
+    LectureDto updateLecture(LectureFormDto lectureFormDto) throws IdNotExistException;
     //강의 삭제
     void deleteLecture(Long lectureId) throws IdNotExistException;
 
     //전체 강의 조회
-    List<Lecture> getLectureByAll();
+    Iterable<LectureDto> getLectureByAll();
 
     //카테고리별 조회
-    List<Lecture> getLectureByCategoryId(Long CategoryId) throws IdNotExistException;
+    Iterable<LectureDto> getLectureByCategoryId(Long CategoryId) throws IdNotExistException;
 
 }

--- a/src/main/java/org/server/remoteclass/service/LectureService.java
+++ b/src/main/java/org/server/remoteclass/service/LectureService.java
@@ -2,7 +2,6 @@ package org.server.remoteclass.service;
 
 import org.server.remoteclass.dto.LectureDto;
 import org.server.remoteclass.dto.LectureFormDto;
-import org.server.remoteclass.entity.Lecture;
 import org.server.remoteclass.exception.IdNotExistException;
 
 import java.util.List;
@@ -19,9 +18,9 @@ public interface LectureService {
     void deleteLecture(Long lectureId) throws IdNotExistException;
 
     //전체 강의 조회
-    Iterable<LectureDto> getLectureByAll();
+    List<LectureDto> getLectureByAll();
 
     //카테고리별 조회
-    Iterable<LectureDto> getLectureByCategoryId(Long CategoryId) throws IdNotExistException;
+    List<LectureDto> getLectureByCategoryId(Long CategoryId) throws IdNotExistException;
 
 }

--- a/src/main/java/org/server/remoteclass/service/LectureServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/LectureServiceImpl.java
@@ -42,12 +42,13 @@ public class LectureServiceImpl implements LectureService{
      * USER_LECTURER만 가능
      */
     @Override
+    @Transactional
     public LectureDto createLecture(LectureFormDto lectureFormDto) throws IdNotExistException {
         User user = SecurityUtil.getCurrentUserEmail()
                 .flatMap(userRepository::findByEmail)
                 .orElseThrow(() -> new IdNotExistException("존재하지 않는 사용자", ResultCode.ID_NOT_EXIST));
 
-        // 현재로그인한 userRole이 user lecturer일때 강의 생성, 아니면 권한없음.
+        // 스프링 시큐리티 컨텍스트에 저장된 User의 Role이 Lecturer인 경우 강의 생성, 아니면 403 반환
 //        if(user.getUserRole() != USER_LECTURER){
 //            throw new InvalidDataAccessApiUsageException("권한 없음");
 //        }
@@ -57,17 +58,8 @@ public class LectureServiceImpl implements LectureService{
         lecture.setCategory(category);
         lecture.setUser(user);
 
-        Lecture result = lectureRepository.save(lecture);
-        return LectureDto.from(
-                result.getDescription(),
-                result.getPrice(),
-                result.getStartDate(),
-                result.getEndDate(),
-                result.getCategory(),
-                result.getUser()
-        );
+        return LectureDto.from(lectureRepository.save(lecture));
     }
-
     /**
      * 특정 강의 조회
      * @param : lectureId
@@ -108,7 +100,7 @@ public class LectureServiceImpl implements LectureService{
         lecture.setCategory(category);
         lecture.setUser(user);
 
-        return lecture;
+        return LectureDto.from(lecture);
     }
 
     /**

--- a/src/main/java/org/server/remoteclass/service/LectureServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/LectureServiceImpl.java
@@ -131,7 +131,7 @@ public class LectureServiceImpl implements LectureService{
      * 강의 전체 조회
      */
     @Override
-    public Iterable<LectureDto> getLectureByAll() {
+    public List<LectureDto> getLectureByAll() {
         ModelMapper mapper = new ModelMapper();
         List<Lecture> lectures = lectureRepository.findAll();
         return lectures.stream().map(lecture -> mapper.map(lecture, LectureDto.class)).collect(Collectors.toList());
@@ -141,7 +141,7 @@ public class LectureServiceImpl implements LectureService{
      * 카테고리별 강의 조회
      */
     @Override
-    public Iterable<LectureDto> getLectureByCategoryId(Long categoryId) throws IdNotExistException{
+    public List<LectureDto> getLectureByCategoryId(Long categoryId) throws IdNotExistException{
         ModelMapper mapper = new ModelMapper();
         categoryRepository.findById(categoryId).orElseThrow(()->new IdNotExistException("존재하지 않는 카테고리", ResultCode.ID_NOT_EXIST));
         Collection<Lecture> lectures = lectureRepository.findByCategoryId(categoryId);

--- a/src/main/java/org/server/remoteclass/service/LectureServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/LectureServiceImpl.java
@@ -4,7 +4,6 @@ import org.modelmapper.ModelMapper;
 
 import org.server.remoteclass.dto.LectureDto;
 import org.server.remoteclass.dto.LectureFormDto;
-import org.server.remoteclass.dto.UserDto;
 import org.server.remoteclass.entity.Category;
 import org.server.remoteclass.entity.Lecture;
 import org.server.remoteclass.entity.User;
@@ -13,6 +12,7 @@ import org.server.remoteclass.exception.ResultCode;
 import org.server.remoteclass.jpa.CategoryRepository;
 import org.server.remoteclass.jpa.LectureRepository;
 import org.server.remoteclass.jpa.UserRepository;
+import org.server.remoteclass.util.BeanConfiguration;
 import org.server.remoteclass.util.SecurityUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
@@ -30,12 +30,17 @@ public class LectureServiceImpl implements LectureService{
     UserRepository userRepository;
     LectureRepository lectureRepository;
     CategoryRepository categoryRepository;
+    BeanConfiguration beanConfiguration;
 
     @Autowired
-    public LectureServiceImpl(UserRepository userRepository, LectureRepository lectureRepository,CategoryRepository categoryRepository){
+    public LectureServiceImpl(UserRepository userRepository,
+                              LectureRepository lectureRepository,
+                              CategoryRepository categoryRepository,
+                              BeanConfiguration beanConfiguration){
         this.userRepository = userRepository;
         this.lectureRepository = lectureRepository;
         this.categoryRepository = categoryRepository;
+        this.beanConfiguration = beanConfiguration;
     }
 
     /**
@@ -53,7 +58,7 @@ public class LectureServiceImpl implements LectureService{
 //        if(user.getUserRole() != USER_LECTURER){
 //            throw new InvalidDataAccessApiUsageException("권한 없음");
 //        }
-        Lecture lecture = new ModelMapper().map(lectureFormDto, Lecture.class);
+        Lecture lecture = beanConfiguration.modelMapper().map(lectureFormDto, Lecture.class);
         Category category = categoryRepository.findById(lectureFormDto.getCategoryId())
                 .orElseThrow(() -> new IdNotExistException("카테고리 존재하지 않음", ResultCode.ID_NOT_EXIST));
         lecture.setCategory(category);
@@ -132,9 +137,9 @@ public class LectureServiceImpl implements LectureService{
      */
     @Override
     public List<LectureDto> getLectureByAll() {
-        ModelMapper mapper = new ModelMapper();
         List<Lecture> lectures = lectureRepository.findAll();
-        return lectures.stream().map(lecture -> mapper.map(lecture, LectureDto.class)).collect(Collectors.toList());
+        return lectures.stream().map(lecture -> beanConfiguration.modelMapper()
+                .map(lecture, LectureDto.class)).collect(Collectors.toList());
     }
 
     /**
@@ -142,9 +147,9 @@ public class LectureServiceImpl implements LectureService{
      */
     @Override
     public List<LectureDto> getLectureByCategoryId(Long categoryId) throws IdNotExistException{
-        ModelMapper mapper = new ModelMapper();
         categoryRepository.findById(categoryId).orElseThrow(()->new IdNotExistException("존재하지 않는 카테고리", ResultCode.ID_NOT_EXIST));
-        Collection<Lecture> lectures = lectureRepository.findByCategoryId(categoryId);
-        return lectures.stream().map(lecture -> mapper.map(lecture, LectureDto.class)).collect(Collectors.toList());
+        List<Lecture> lectures = lectureRepository.findByCategoryId(categoryId);
+        return lectures.stream().map(lecture -> beanConfiguration.modelMapper()
+                .map(lecture, LectureDto.class)).collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/server/remoteclass/service/LectureServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/LectureServiceImpl.java
@@ -19,7 +19,6 @@ import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/org/server/remoteclass/service/LectureServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/LectureServiceImpl.java
@@ -43,7 +43,7 @@ public class LectureServiceImpl implements LectureService{
     @Override
     public Lecture createLecture(LectureFormDto lectureFormDto) throws IdNotExistException {
         User user = SecurityUtil.getCurrentUserEmail()
-                .flatMap(userRepository::findOneWithAuthoritiesByEmail)
+                .flatMap(userRepository::findByEmail)
                 .orElseThrow(() -> new IdNotExistException("존재하지 않는 사용자", ResultCode.ID_NOT_EXIST));
 
         // 현재로그인한 userRole이 user lecturer일때 강의 생성, 아니면 권한없음.
@@ -70,7 +70,6 @@ public class LectureServiceImpl implements LectureService{
                 .orElseThrow(() -> new IdNotExistException("존재하지 않는 강의", ResultCode.ID_NOT_EXIST));
     }
 
-
     /**
      * 강의 수정
      * 생성자만 수정 가능
@@ -80,7 +79,7 @@ public class LectureServiceImpl implements LectureService{
     public Lecture updateLecture(LectureFormDto lectureFormDto) throws IdNotExistException{
         //check user and authorities
         User user = SecurityUtil.getCurrentUserEmail()
-                .flatMap(userRepository::findOneWithAuthoritiesByEmail)
+                .flatMap(userRepository::findByEmail)
                 .orElseThrow(() -> new IdNotExistException("존재하지 않는 사용자", ResultCode.ID_NOT_EXIST));
 
         Lecture lecture = lectureRepository.findById(lectureFormDto.getLectureId())
@@ -115,7 +114,7 @@ public class LectureServiceImpl implements LectureService{
     public void deleteLecture(Long lectureId) throws IdNotExistException{
         //check user and check if user has delete authority
         User user = SecurityUtil.getCurrentUserEmail()
-                .flatMap(userRepository::findOneWithAuthoritiesByEmail)
+                .flatMap(userRepository::findByEmail)
                 .orElseThrow(() -> new IdNotExistException("존재하지 않는 사용자", ResultCode.ID_NOT_EXIST));
 
         Lecture lecture = lectureRepository.findById(lectureId)

--- a/src/main/java/org/server/remoteclass/service/LectureServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/LectureServiceImpl.java
@@ -27,10 +27,10 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class LectureServiceImpl implements LectureService{
 
-    UserRepository userRepository;
-    LectureRepository lectureRepository;
-    CategoryRepository categoryRepository;
-    BeanConfiguration beanConfiguration;
+    private final UserRepository userRepository;
+    private final LectureRepository lectureRepository;
+    private final CategoryRepository categoryRepository;
+    private final ModelMapper modelMapper;
 
     @Autowired
     public LectureServiceImpl(UserRepository userRepository,
@@ -40,7 +40,7 @@ public class LectureServiceImpl implements LectureService{
         this.userRepository = userRepository;
         this.lectureRepository = lectureRepository;
         this.categoryRepository = categoryRepository;
-        this.beanConfiguration = beanConfiguration;
+        this.modelMapper = beanConfiguration.modelMapper();
     }
 
     /**
@@ -58,7 +58,7 @@ public class LectureServiceImpl implements LectureService{
 //        if(user.getUserRole() != USER_LECTURER){
 //            throw new InvalidDataAccessApiUsageException("권한 없음");
 //        }
-        Lecture lecture = beanConfiguration.modelMapper().map(lectureFormDto, Lecture.class);
+        Lecture lecture = modelMapper.map(lectureFormDto, Lecture.class);
         Category category = categoryRepository.findById(lectureFormDto.getCategoryId())
                 .orElseThrow(() -> new IdNotExistException("카테고리 존재하지 않음", ResultCode.ID_NOT_EXIST));
         lecture.setCategory(category);
@@ -138,7 +138,7 @@ public class LectureServiceImpl implements LectureService{
     @Override
     public List<LectureDto> getLectureByAll() {
         List<Lecture> lectures = lectureRepository.findAll();
-        return lectures.stream().map(lecture -> beanConfiguration.modelMapper()
+        return lectures.stream().map(lecture -> modelMapper
                 .map(lecture, LectureDto.class)).collect(Collectors.toList());
     }
 
@@ -149,7 +149,7 @@ public class LectureServiceImpl implements LectureService{
     public List<LectureDto> getLectureByCategoryId(Long categoryId) throws IdNotExistException{
         categoryRepository.findById(categoryId).orElseThrow(()->new IdNotExistException("존재하지 않는 카테고리", ResultCode.ID_NOT_EXIST));
         List<Lecture> lectures = lectureRepository.findByCategoryId(categoryId);
-        return lectures.stream().map(lecture -> beanConfiguration.modelMapper()
+        return lectures.stream().map(lecture -> modelMapper
                 .map(lecture, LectureDto.class)).collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/server/remoteclass/service/LectureServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/LectureServiceImpl.java
@@ -2,6 +2,7 @@ package org.server.remoteclass.service;
 
 import org.modelmapper.ModelMapper;
 
+import org.server.remoteclass.dto.LectureDto;
 import org.server.remoteclass.dto.LectureFormDto;
 import org.server.remoteclass.entity.Category;
 import org.server.remoteclass.entity.Lecture;
@@ -41,7 +42,7 @@ public class LectureServiceImpl implements LectureService{
      * USER_LECTURER만 가능
      */
     @Override
-    public Lecture createLecture(LectureFormDto lectureFormDto) throws IdNotExistException {
+    public LectureDto createLecture(LectureFormDto lectureFormDto) throws IdNotExistException {
         User user = SecurityUtil.getCurrentUserEmail()
                 .flatMap(userRepository::findByEmail)
                 .orElseThrow(() -> new IdNotExistException("존재하지 않는 사용자", ResultCode.ID_NOT_EXIST));
@@ -57,7 +58,14 @@ public class LectureServiceImpl implements LectureService{
         lecture.setUser(user);
 
         Lecture result = lectureRepository.save(lecture);
-        return result;
+        return LectureDto.from(
+                result.getDescription(),
+                result.getPrice(),
+                result.getStartDate(),
+                result.getEndDate(),
+                result.getCategory(),
+                result.getUser()
+        );
     }
 
     /**
@@ -65,7 +73,7 @@ public class LectureServiceImpl implements LectureService{
      * @param : lectureId
      */
     @Override
-    public Lecture getLectureByLectureId(Long lectureId) throws IdNotExistException {
+    public LectureDto getLectureByLectureId(Long lectureId) throws IdNotExistException {
         return lectureRepository.findById(lectureId)
                 .orElseThrow(() -> new IdNotExistException("존재하지 않는 강의", ResultCode.ID_NOT_EXIST));
     }
@@ -76,7 +84,7 @@ public class LectureServiceImpl implements LectureService{
      */
     @Override
     @Transactional
-    public Lecture updateLecture(LectureFormDto lectureFormDto) throws IdNotExistException{
+    public LectureDto updateLecture(LectureFormDto lectureFormDto) throws IdNotExistException{
         //check user and authorities
         User user = SecurityUtil.getCurrentUserEmail()
                 .flatMap(userRepository::findByEmail)
@@ -129,7 +137,7 @@ public class LectureServiceImpl implements LectureService{
      * 강의 전체 조회
      */
     @Override
-    public List<Lecture> getLectureByAll() {
+    public Iterable<LectureDto> getLectureByAll() {
         return lectureRepository.findAll();
     }
 
@@ -137,7 +145,7 @@ public class LectureServiceImpl implements LectureService{
      * 카테고리별 강의 조회
      */
     @Override
-    public List<Lecture> getLectureByCategoryId(Long categoryId) throws IdNotExistException{
+    public Iterable<LectureDto> getLectureByCategoryId(Long categoryId) throws IdNotExistException{
 
         Category category = categoryRepository.findById(categoryId).orElseThrow(()->new IdNotExistException("존재하지 않는 카테고리", ResultCode.ID_NOT_EXIST));
         Collection<Lecture> lectures = lectureRepository.findByCategoryId(categoryId);

--- a/src/main/java/org/server/remoteclass/service/StudentService.java
+++ b/src/main/java/org/server/remoteclass/service/StudentService.java
@@ -1,5 +1,6 @@
 package org.server.remoteclass.service;
 
+import org.server.remoteclass.dto.StudentDto;
 import org.server.remoteclass.dto.StudentFormDto;
 import org.server.remoteclass.entity.Student;
 import org.server.remoteclass.exception.IdNotExistException;
@@ -9,10 +10,10 @@ import java.util.List;
 public interface StudentService {
 
 //    //수강신청
-    Student applyLecture(StudentFormDto studentFormDto) throws IdNotExistException;
+    StudentDto applyLecture(StudentFormDto studentFormDto) throws IdNotExistException;
     //강좌별 전체 수강생 조회
-    List<Student> getStudentsByLectureId(Long lectureId) throws IdNotExistException;
+    Iterable<StudentDto> getStudentsByLectureId(Long lectureId) throws IdNotExistException;
     //한 수강생의 수강 강좌 리스트 조회
-    List<Student> getLecturesByUserId() throws IdNotExistException;
+    Iterable<StudentDto> getLecturesByUserId() throws IdNotExistException;
 
 }

--- a/src/main/java/org/server/remoteclass/service/StudentService.java
+++ b/src/main/java/org/server/remoteclass/service/StudentService.java
@@ -3,18 +3,17 @@ package org.server.remoteclass.service;
 import org.server.remoteclass.dto.LectureDto;
 import org.server.remoteclass.dto.StudentDto;
 import org.server.remoteclass.dto.StudentFormDto;
-import org.server.remoteclass.entity.Student;
 import org.server.remoteclass.exception.IdNotExistException;
 
 import java.util.List;
 
 public interface StudentService {
 
-//    //수강신청
+    //수강신청
     StudentDto applyLecture(StudentFormDto studentFormDto) throws IdNotExistException;
     //강좌별 전체 수강생 조회
-    Iterable<StudentDto> getStudentsByLectureId(Long lectureId) throws IdNotExistException;
+    List<StudentDto> getStudentsByLectureId(Long lectureId) throws IdNotExistException;
     //한 수강생의 수강 강좌 리스트 조회
-    Iterable<LectureDto> getLecturesByUserId() throws IdNotExistException;
+    List<LectureDto> getLecturesByUserId() throws IdNotExistException;
 
 }

--- a/src/main/java/org/server/remoteclass/service/StudentService.java
+++ b/src/main/java/org/server/remoteclass/service/StudentService.java
@@ -1,5 +1,6 @@
 package org.server.remoteclass.service;
 
+import org.server.remoteclass.dto.LectureDto;
 import org.server.remoteclass.dto.StudentDto;
 import org.server.remoteclass.dto.StudentFormDto;
 import org.server.remoteclass.entity.Student;
@@ -14,6 +15,6 @@ public interface StudentService {
     //강좌별 전체 수강생 조회
     Iterable<StudentDto> getStudentsByLectureId(Long lectureId) throws IdNotExistException;
     //한 수강생의 수강 강좌 리스트 조회
-    Iterable<StudentDto> getLecturesByUserId() throws IdNotExistException;
+    Iterable<LectureDto> getLecturesByUserId() throws IdNotExistException;
 
 }

--- a/src/main/java/org/server/remoteclass/service/StudentServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/StudentServiceImpl.java
@@ -1,8 +1,10 @@
 package org.server.remoteclass.service;
 
 import org.modelmapper.ModelMapper;
+import org.server.remoteclass.dto.LectureDto;
 import org.server.remoteclass.dto.StudentDto;
 import org.server.remoteclass.dto.StudentFormDto;
+import org.server.remoteclass.dto.UserDto;
 import org.server.remoteclass.entity.Lecture;
 import org.server.remoteclass.entity.Student;
 import org.server.remoteclass.entity.User;
@@ -24,9 +26,9 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class StudentServiceImpl implements StudentService{
 
-    UserRepository userRepository;
-    LectureRepository lectureRepository;
-    StudentRepository studentRepository;
+    private final UserRepository userRepository;
+    private final LectureRepository lectureRepository;
+    private final StudentRepository studentRepository;
 
     @Autowired
     public StudentServiceImpl(UserRepository userRepository, LectureRepository lectureRepository,StudentRepository studentRepository){
@@ -38,57 +40,49 @@ public class StudentServiceImpl implements StudentService{
     @Override
     @Transactional
     public StudentDto applyLecture(StudentFormDto studentFormDto) throws IdNotExistException{
+
+        // 이 부분이 3번 반복이라, 공통적으로 뺄 수 있으면 좋을 것 같습니다. 생성자에서 초기화 해도 되는지 모르겠네요.
         User user = SecurityUtil.getCurrentUserEmail()
                 .flatMap(userRepository::findByEmail)
                 .orElseThrow(() -> new IdNotExistException("존재하지 않는 사용자", ResultCode.ID_NOT_EXIST));
-
 //        //학생 권한인지 확인하고
 //        if(user.getUserRole() == USER_STUDENT){
 //            //학생 권한이면 강의번호 있는지 확인한다.
-            Lecture lecture = lectureRepository.findById(studentFormDto.getLectureId())
-                    .orElseThrow(()->new IdNotExistException("존재하지 않는 강의", ResultCode.ID_NOT_EXIST));
             ////강의도 존재하면
             Student student = new ModelMapper().map(studentFormDto, Student.class);
             student.setUser(user);
-            student.setLecture(lecture);
+            student.setLecture(lectureRepository.findById(studentFormDto.getLectureId()).orElse(null));
             return StudentDto.from(studentRepository.save(student));
         }
 
     //강좌별 전체 수강생 목록
     @Override
     public Iterable<StudentDto> getStudentsByLectureId(Long lectureId) throws IdNotExistException{
-        Collection<Student> students;
 
         User user = SecurityUtil.getCurrentUserEmail()
                 .flatMap(userRepository::findByEmail)
                 .orElseThrow(() -> new IdNotExistException("존재하지 않는 사용자", ResultCode.ID_NOT_EXIST));
-        Lecture lecture = lectureRepository.findById(lectureId)
-                .orElseThrow(() -> new IdNotExistException("존재하지 않는 강의", ResultCode.ID_NOT_EXIST));
 
         //현재 사용자 권한이 강의자이고, 해당 강의의 author와 같다면 조회 가능
 //        if(user.getRole()==USER_LECTURER && user.getUserId() == lecture.getUser().getUserId()){
-            students = studentRepository.findByLectureId(lectureId); // 수강생이 존재하지 않는 예외 필요
-            if(students.isEmpty()){
-                throw new IllegalStateException("수강생이 존재하지 않는 강의");
-            }
-        return students.stream().collect(Collectors.toList());
+        ModelMapper mapper = new ModelMapper();
+        List<Student> students = studentRepository.findAll();
+        //수강생이 없는 강의도 있다고 생각해서 예외처리 부분 지웠어요. 새로 만든 강의의 경우 수강생이 0명일 수 밖에 없다고 생각했어요.
+        return students.stream().map(student -> mapper.map(student, StudentDto.class)).collect(Collectors.toList());
     }
 
 
     //현재 수강생의 수강 강좌 리스트 조회
     @Override
-    public Iterable<StudentDto> getLecturesByUserId() throws IdNotExistException{
-        Collection<Student> students;
+    public Iterable<LectureDto> getLecturesByUserId() throws IdNotExistException{
         //현재 사용자 확인
         User user = SecurityUtil.getCurrentUserEmail()
                 .flatMap(userRepository::findByEmail)
                 .orElseThrow(() -> new IdNotExistException("존재하지 않는 사용자", ResultCode.ID_NOT_EXIST));
         // 현재 사용자의 userId를 가진 student들을 조회
-        students = studentRepository.findByUserId(user.getUserId());
-        if(students.isEmpty()){
-            throw new IllegalStateException("신청한 강의가 없습니다.");
-        }
-        return students.stream().collect(Collectors.toList());
+        ModelMapper mapper = new ModelMapper();
+        Collection<Lecture> lectures = studentRepository.findByUserId(user.getUserId());
+        return lectures.stream().map(lecture -> mapper.map(lecture, LectureDto.class)).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/org/server/remoteclass/service/StudentServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/StudentServiceImpl.java
@@ -81,7 +81,7 @@ public class StudentServiceImpl implements StudentService{
                 .orElseThrow(() -> new IdNotExistException("존재하지 않는 사용자", ResultCode.ID_NOT_EXIST));
         // 현재 사용자의 userId를 가진 student들을 조회
         ModelMapper mapper = new ModelMapper();
-        Collection<Lecture> lectures = studentRepository.findByUserId(user.getUserId());
+        Collection<Lecture> lectures = studentRepository.findByStudentId(user.getUserId());
         return lectures.stream().map(lecture -> mapper.map(lecture, LectureDto.class)).collect(Collectors.toList());
     }
 

--- a/src/main/java/org/server/remoteclass/service/StudentServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/StudentServiceImpl.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@Transactional(readOnly = true)
 public class StudentServiceImpl implements StudentService{
 
     UserRepository userRepository;
@@ -35,6 +36,7 @@ public class StudentServiceImpl implements StudentService{
     }
 
     @Override
+    @Transactional
     public StudentDto applyLecture(StudentFormDto studentFormDto) throws IdNotExistException{
         User user = SecurityUtil.getCurrentUserEmail()
                 .flatMap(userRepository::findByEmail)
@@ -49,17 +51,11 @@ public class StudentServiceImpl implements StudentService{
             Student student = new ModelMapper().map(studentFormDto, Student.class);
             student.setUser(user);
             student.setLecture(lecture);
-            Student result = studentRepository.save(student);
-            return result;
+            return StudentDto.from(studentRepository.save(student));
         }
-//        else{
-//            throw new InvalidDataAccessApiUsageException("수강 신청 권한 없음");
-//        }
-//    }
 
     //강좌별 전체 수강생 목록
     @Override
-    @Transactional(readOnly = true)
     public Iterable<StudentDto> getStudentsByLectureId(Long lectureId) throws IdNotExistException{
         Collection<Student> students;
 
@@ -75,17 +71,12 @@ public class StudentServiceImpl implements StudentService{
             if(students.isEmpty()){
                 throw new IllegalStateException("수강생이 존재하지 않는 강의");
             }
-//        }
-//        else{
-//            throw new InvalidDataAccessApiUsageException("조회 권한이 없습니다.");
-//        }
         return students.stream().collect(Collectors.toList());
     }
 
 
     //현재 수강생의 수강 강좌 리스트 조회
     @Override
-    @Transactional(readOnly = true)
     public Iterable<StudentDto> getLecturesByUserId() throws IdNotExistException{
         Collection<Student> students;
         //현재 사용자 확인

--- a/src/main/java/org/server/remoteclass/service/StudentServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/StudentServiceImpl.java
@@ -57,7 +57,7 @@ public class StudentServiceImpl implements StudentService{
 
     //강좌별 전체 수강생 목록
     @Override
-    public Iterable<StudentDto> getStudentsByLectureId(Long lectureId) throws IdNotExistException{
+    public List<StudentDto> getStudentsByLectureId(Long lectureId) throws IdNotExistException{
 
         User user = SecurityUtil.getCurrentUserEmail()
                 .flatMap(userRepository::findByEmail)
@@ -74,7 +74,7 @@ public class StudentServiceImpl implements StudentService{
 
     //현재 수강생의 수강 강좌 리스트 조회
     @Override
-    public Iterable<LectureDto> getLecturesByUserId() throws IdNotExistException{
+    public List<LectureDto> getLecturesByUserId() throws IdNotExistException{
         //현재 사용자 확인
         User user = SecurityUtil.getCurrentUserEmail()
                 .flatMap(userRepository::findByEmail)

--- a/src/main/java/org/server/remoteclass/service/StudentServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/StudentServiceImpl.java
@@ -1,6 +1,7 @@
 package org.server.remoteclass.service;
 
 import org.modelmapper.ModelMapper;
+import org.server.remoteclass.dto.StudentDto;
 import org.server.remoteclass.dto.StudentFormDto;
 import org.server.remoteclass.entity.Lecture;
 import org.server.remoteclass.entity.Student;
@@ -34,9 +35,9 @@ public class StudentServiceImpl implements StudentService{
     }
 
     @Override
-    public Student applyLecture(StudentFormDto studentFormDto) throws IdNotExistException{
+    public StudentDto applyLecture(StudentFormDto studentFormDto) throws IdNotExistException{
         User user = SecurityUtil.getCurrentUserEmail()
-                .flatMap(userRepository::findOneWithAuthoritiesByEmail)
+                .flatMap(userRepository::findByEmail)
                 .orElseThrow(() -> new IdNotExistException("존재하지 않는 사용자", ResultCode.ID_NOT_EXIST));
 
 //        //학생 권한인지 확인하고
@@ -59,7 +60,7 @@ public class StudentServiceImpl implements StudentService{
     //강좌별 전체 수강생 목록
     @Override
     @Transactional(readOnly = true)
-    public List<Student> getStudentsByLectureId(Long lectureId) throws IdNotExistException{
+    public Iterable<StudentDto> getStudentsByLectureId(Long lectureId) throws IdNotExistException{
         Collection<Student> students;
 
         User user = SecurityUtil.getCurrentUserEmail()
@@ -85,7 +86,7 @@ public class StudentServiceImpl implements StudentService{
     //현재 수강생의 수강 강좌 리스트 조회
     @Override
     @Transactional(readOnly = true)
-    public List<Student> getLecturesByUserId() throws IdNotExistException{
+    public Iterable<StudentDto> getLecturesByUserId() throws IdNotExistException{
         Collection<Student> students;
         //현재 사용자 확인
         User user = SecurityUtil.getCurrentUserEmail()

--- a/src/main/java/org/server/remoteclass/service/StudentServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/StudentServiceImpl.java
@@ -4,7 +4,6 @@ import org.modelmapper.ModelMapper;
 import org.server.remoteclass.dto.LectureDto;
 import org.server.remoteclass.dto.StudentDto;
 import org.server.remoteclass.dto.StudentFormDto;
-import org.server.remoteclass.dto.UserDto;
 import org.server.remoteclass.entity.Lecture;
 import org.server.remoteclass.entity.Student;
 import org.server.remoteclass.entity.User;
@@ -13,12 +12,12 @@ import org.server.remoteclass.exception.ResultCode;
 import org.server.remoteclass.jpa.LectureRepository;
 import org.server.remoteclass.jpa.StudentRepository;
 import org.server.remoteclass.jpa.UserRepository;
+import org.server.remoteclass.util.BeanConfiguration;
 import org.server.remoteclass.util.SecurityUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -29,12 +28,15 @@ public class StudentServiceImpl implements StudentService{
     private final UserRepository userRepository;
     private final LectureRepository lectureRepository;
     private final StudentRepository studentRepository;
+    private final BeanConfiguration beanConfiguration;
 
     @Autowired
-    public StudentServiceImpl(UserRepository userRepository, LectureRepository lectureRepository,StudentRepository studentRepository){
+    public StudentServiceImpl(UserRepository userRepository, LectureRepository lectureRepository,
+                              StudentRepository studentRepository, BeanConfiguration beanConfiguration){
         this.userRepository = userRepository;
         this.lectureRepository = lectureRepository;
         this.studentRepository = studentRepository;
+        this.beanConfiguration = beanConfiguration;
     }
 
     @Override
@@ -49,7 +51,7 @@ public class StudentServiceImpl implements StudentService{
 //        if(user.getUserRole() == USER_STUDENT){
 //            //학생 권한이면 강의번호 있는지 확인한다.
             ////강의도 존재하면
-            Student student = new ModelMapper().map(studentFormDto, Student.class);
+            Student student = beanConfiguration.modelMapper().map(studentFormDto, Student.class);
             student.setUser(user);
             student.setLecture(lectureRepository.findById(studentFormDto.getLectureId()).orElse(null));
             return StudentDto.from(studentRepository.save(student));
@@ -65,10 +67,10 @@ public class StudentServiceImpl implements StudentService{
 
         //현재 사용자 권한이 강의자이고, 해당 강의의 author와 같다면 조회 가능
 //        if(user.getRole()==USER_LECTURER && user.getUserId() == lecture.getUser().getUserId()){
-        ModelMapper mapper = new ModelMapper();
         List<Student> students = studentRepository.findAll();
         //수강생이 없는 강의도 있다고 생각해서 예외처리 부분 지웠어요. 새로 만든 강의의 경우 수강생이 0명일 수 밖에 없다고 생각했어요.
-        return students.stream().map(student -> mapper.map(student, StudentDto.class)).collect(Collectors.toList());
+        return students.stream().map(student -> beanConfiguration.modelMapper().map(student, StudentDto.class))
+                .collect(Collectors.toList());
     }
 
 
@@ -80,9 +82,8 @@ public class StudentServiceImpl implements StudentService{
                 .flatMap(userRepository::findByEmail)
                 .orElseThrow(() -> new IdNotExistException("존재하지 않는 사용자", ResultCode.ID_NOT_EXIST));
         // 현재 사용자의 userId를 가진 student들을 조회
-        ModelMapper mapper = new ModelMapper();
-        Collection<Lecture> lectures = studentRepository.findByStudentId(user.getUserId());
-        return lectures.stream().map(lecture -> mapper.map(lecture, LectureDto.class)).collect(Collectors.toList());
+        List<Lecture> lectures = studentRepository.findByStudentId(user.getUserId());
+        return lectures.stream().map(lecture -> beanConfiguration.modelMapper().map(lecture, LectureDto.class)).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/org/server/remoteclass/service/StudentServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/StudentServiceImpl.java
@@ -33,7 +33,6 @@ public class StudentServiceImpl implements StudentService{
         this.studentRepository = studentRepository;
     }
 
-
     @Override
     public Student applyLecture(StudentFormDto studentFormDto) throws IdNotExistException{
         User user = SecurityUtil.getCurrentUserEmail()
@@ -64,7 +63,7 @@ public class StudentServiceImpl implements StudentService{
         Collection<Student> students;
 
         User user = SecurityUtil.getCurrentUserEmail()
-                .flatMap(userRepository::findOneWithAuthoritiesByEmail)
+                .flatMap(userRepository::findByEmail)
                 .orElseThrow(() -> new IdNotExistException("존재하지 않는 사용자", ResultCode.ID_NOT_EXIST));
         Lecture lecture = lectureRepository.findById(lectureId)
                 .orElseThrow(() -> new IdNotExistException("존재하지 않는 강의", ResultCode.ID_NOT_EXIST));
@@ -90,7 +89,7 @@ public class StudentServiceImpl implements StudentService{
         Collection<Student> students;
         //현재 사용자 확인
         User user = SecurityUtil.getCurrentUserEmail()
-                .flatMap(userRepository::findOneWithAuthoritiesByEmail)
+                .flatMap(userRepository::findByEmail)
                 .orElseThrow(() -> new IdNotExistException("존재하지 않는 사용자", ResultCode.ID_NOT_EXIST));
         // 현재 사용자의 userId를 가진 student들을 조회
         students = studentRepository.findByUserId(user.getUserId());

--- a/src/main/java/org/server/remoteclass/service/StudentServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/StudentServiceImpl.java
@@ -28,7 +28,7 @@ public class StudentServiceImpl implements StudentService{
     private final UserRepository userRepository;
     private final LectureRepository lectureRepository;
     private final StudentRepository studentRepository;
-    private final BeanConfiguration beanConfiguration;
+    private final ModelMapper modelMapper;
 
     @Autowired
     public StudentServiceImpl(UserRepository userRepository, LectureRepository lectureRepository,
@@ -36,7 +36,7 @@ public class StudentServiceImpl implements StudentService{
         this.userRepository = userRepository;
         this.lectureRepository = lectureRepository;
         this.studentRepository = studentRepository;
-        this.beanConfiguration = beanConfiguration;
+        this.modelMapper = beanConfiguration.modelMapper();
     }
 
     @Override
@@ -51,7 +51,7 @@ public class StudentServiceImpl implements StudentService{
 //        if(user.getUserRole() == USER_STUDENT){
 //            //학생 권한이면 강의번호 있는지 확인한다.
             ////강의도 존재하면
-            Student student = beanConfiguration.modelMapper().map(studentFormDto, Student.class);
+            Student student = modelMapper.map(studentFormDto, Student.class);
             student.setUser(user);
             student.setLecture(lectureRepository.findById(studentFormDto.getLectureId()).orElse(null));
             return StudentDto.from(studentRepository.save(student));
@@ -69,7 +69,7 @@ public class StudentServiceImpl implements StudentService{
 //        if(user.getRole()==USER_LECTURER && user.getUserId() == lecture.getUser().getUserId()){
         List<Student> students = studentRepository.findAll();
         //수강생이 없는 강의도 있다고 생각해서 예외처리 부분 지웠어요. 새로 만든 강의의 경우 수강생이 0명일 수 밖에 없다고 생각했어요.
-        return students.stream().map(student -> beanConfiguration.modelMapper().map(student, StudentDto.class))
+        return students.stream().map(student -> modelMapper.map(student, StudentDto.class))
                 .collect(Collectors.toList());
     }
 
@@ -83,7 +83,7 @@ public class StudentServiceImpl implements StudentService{
                 .orElseThrow(() -> new IdNotExistException("존재하지 않는 사용자", ResultCode.ID_NOT_EXIST));
         // 현재 사용자의 userId를 가진 student들을 조회
         List<Lecture> lectures = studentRepository.findByStudentId(user.getUserId());
-        return lectures.stream().map(lecture -> beanConfiguration.modelMapper().map(lecture, LectureDto.class)).collect(Collectors.toList());
+        return lectures.stream().map(lecture -> modelMapper.map(lecture, LectureDto.class)).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/org/server/remoteclass/service/UserService.java
+++ b/src/main/java/org/server/remoteclass/service/UserService.java
@@ -2,10 +2,11 @@ package org.server.remoteclass.service;
 import org.server.remoteclass.dto.UserDto;
 import org.server.remoteclass.entity.User;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserService {
     UserDto getUserWithAuthorities(String email);
     UserDto getMyUserWithAuthorities();
-    Iterable<UserDto> getUsersByAll()
+    List<UserDto> getUsersByAll();
 }

--- a/src/main/java/org/server/remoteclass/service/UserService.java
+++ b/src/main/java/org/server/remoteclass/service/UserService.java
@@ -6,6 +6,6 @@ import java.util.Optional;
 
 public interface UserService {
     UserDto getUserWithAuthorities(String email);
-    Optional<User> getMyUserWithAuthorities();
-    Iterable<User> getUsersByAll();
+    UserDto getMyUserWithAuthorities();
+    Iterable<UserDto> getUsersByAll()
 }

--- a/src/main/java/org/server/remoteclass/service/UserService.java
+++ b/src/main/java/org/server/remoteclass/service/UserService.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 public interface UserService {
     UserDto getUserWithAuthorities(String email);
     UserDto getMyUserWithAuthorities();
-    Iterable<UserDto> getUsersByAll();
+    List<UserDto> getUsersByAll();
 }

--- a/src/main/java/org/server/remoteclass/service/UserService.java
+++ b/src/main/java/org/server/remoteclass/service/UserService.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 public interface UserService {
     UserDto getUserWithAuthorities(String email);
     UserDto getMyUserWithAuthorities();
-    List<UserDto> getUsersByAll();
+    Iterable<UserDto> getUsersByAll();
 }

--- a/src/main/java/org/server/remoteclass/service/UserServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/UserServiceImpl.java
@@ -39,12 +39,10 @@ public class UserServiceImpl implements UserService{
     }
 
     @Override
-    public Iterable<UserDto> getUsersByAll(){
+    public List<UserDto> getUsersByAll(){
         ModelMapper mapper = new ModelMapper();
         List<User> users = userRepository.findAll();
-        //Iterable 형태로 반환하는 게 맞겠죠?(최대한 추상적인 자료형으로 반환하는 것으로 반환시켰어요)
-        Iterable<UserDto> userList = users.stream().map(user -> mapper.map(user, UserDto.class)).collect(Collectors.toList());
-        return userList;
+        return users.stream().map(user -> mapper.map(user, UserDto.class)).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/org/server/remoteclass/service/UserServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/UserServiceImpl.java
@@ -42,7 +42,7 @@ public class UserServiceImpl implements UserService{
     public Iterable<UserDto> getUsersByAll(){
         ModelMapper mapper = new ModelMapper();
         List<User> users = userRepository.findAll();
-        //Iterable 형태로 반환하는 게 맞는지..?
+        //Iterable 형태로 반환하는 게 맞겠죠?(최대한 추상적인 자료형으로 반환하는 것으로 반환시켰어요)
         Iterable<UserDto> userList = users.stream().map(user -> mapper.map(user, UserDto.class)).collect(Collectors.toList());
         return userList;
     }

--- a/src/main/java/org/server/remoteclass/service/UserServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/UserServiceImpl.java
@@ -40,9 +40,8 @@ public class UserServiceImpl implements UserService{
 
     @Override
     public List<UserDto> getUsersByAll(){
-        ModelMapper mapper = new ModelMapper();
         List<User> users = userRepository.findAll();
-        return users.stream().map(user -> mapper.map(user, UserDto.class)).collect(Collectors.toList());
+        return users.stream().map(user -> beanConfiguration.modelMapper().map(user, UserDto.class)).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/org/server/remoteclass/service/UserServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/UserServiceImpl.java
@@ -44,9 +44,9 @@ public class UserServiceImpl implements UserService{
     public Iterable<UserDto> getUsersByAll(){
         ModelMapper mapper = new ModelMapper();
         List<User> users = userRepository.findAll();
+        //Iterable 형태로 반환하는 게 맞는지..?
         Iterable<UserDto> userList = users.stream().map(user -> mapper.map(user, UserDto.class)).collect(Collectors.toList());
         return userList;
-//        return userRepository.findAll();
     }
 
 }

--- a/src/main/java/org/server/remoteclass/service/UserServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/UserServiceImpl.java
@@ -1,26 +1,32 @@
 package org.server.remoteclass.service;
 
 import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.ModelMapper;
 import org.server.remoteclass.dto.UserDto;
 import org.server.remoteclass.entity.User;
 import org.server.remoteclass.jpa.UserRepository;
+import org.server.remoteclass.util.BeanConfiguration;
 import org.server.remoteclass.util.SecurityUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
 public class UserServiceImpl implements UserService{
 
     private final UserRepository userRepository;
+    private final BeanConfiguration beanConfiguration;
 
     @Autowired
-    public UserServiceImpl(UserRepository userRepository){
+    public UserServiceImpl(UserRepository userRepository, BeanConfiguration beanConfiguration){
         this.userRepository = userRepository;
+        this.beanConfiguration = beanConfiguration;
     }
 
     @Transactional(readOnly = true)
@@ -38,9 +44,12 @@ public class UserServiceImpl implements UserService{
 
     @Transactional(readOnly = true)
     @Override
-    public Iterable<UserDto> getUsersByAll(){
-        Iterable<UserDto> userDtoIterable = userRepository.findAll().stream().map(user -> model)
-        return userRepository.findAll();
+    public List<UserDto> getUsersByAll(){
+        ModelMapper mapper = new ModelMapper();
+        List<User> users = userRepository.findAll();
+        List<UserDto> userList = users.stream().map(user -> mapper.map(user, UserDto.class)).collect(Collectors.toList());
+        return userList;
+//        return userRepository.findAll();
     }
 
 }

--- a/src/main/java/org/server/remoteclass/service/UserServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/UserServiceImpl.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 
 @Service
 @Slf4j
+@Transactional(readOnly = true)
 public class UserServiceImpl implements UserService{
 
     private final UserRepository userRepository;
@@ -26,20 +27,17 @@ public class UserServiceImpl implements UserService{
         this.beanConfiguration = beanConfiguration;
     }
 
-    @Transactional(readOnly = true)
     @Override
     public UserDto getUserWithAuthorities(String email){
         return UserDto.from(userRepository.findByEmail(email).orElse(null));
     }
 
     //현재 스프링 시큐리티 컨텍스트에 있는 유저 반환
-    @Transactional(readOnly = true)
     @Override
     public UserDto getMyUserWithAuthorities(){
         return UserDto.from(SecurityUtil.getCurrentUserEmail().flatMap(userRepository::findByEmail).orElse(null));
     }
 
-    @Transactional(readOnly = true)
     @Override
     public Iterable<UserDto> getUsersByAll(){
         ModelMapper mapper = new ModelMapper();

--- a/src/main/java/org/server/remoteclass/service/UserServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/UserServiceImpl.java
@@ -19,12 +19,12 @@ import java.util.stream.Collectors;
 public class UserServiceImpl implements UserService{
 
     private final UserRepository userRepository;
-    private final BeanConfiguration beanConfiguration;
+    private final ModelMapper modelMapper;
 
     @Autowired
     public UserServiceImpl(UserRepository userRepository, BeanConfiguration beanConfiguration){
         this.userRepository = userRepository;
-        this.beanConfiguration = beanConfiguration;
+        this.modelMapper = beanConfiguration.modelMapper();
     }
 
     @Override
@@ -41,7 +41,7 @@ public class UserServiceImpl implements UserService{
     @Override
     public List<UserDto> getUsersByAll(){
         List<User> users = userRepository.findAll();
-        return users.stream().map(user -> beanConfiguration.modelMapper().map(user, UserDto.class)).collect(Collectors.toList());
+        return users.stream().map(user -> modelMapper.map(user, UserDto.class)).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/org/server/remoteclass/service/UserServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/UserServiceImpl.java
@@ -10,10 +10,7 @@ import org.server.remoteclass.util.SecurityUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service

--- a/src/main/java/org/server/remoteclass/service/UserServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/UserServiceImpl.java
@@ -41,10 +41,10 @@ public class UserServiceImpl implements UserService{
 
     @Transactional(readOnly = true)
     @Override
-    public List<UserDto> getUsersByAll(){
+    public Iterable<UserDto> getUsersByAll(){
         ModelMapper mapper = new ModelMapper();
         List<User> users = userRepository.findAll();
-        List<UserDto> userList = users.stream().map(user -> mapper.map(user, UserDto.class)).collect(Collectors.toList());
+        Iterable<UserDto> userList = users.stream().map(user -> mapper.map(user, UserDto.class)).collect(Collectors.toList());
         return userList;
 //        return userRepository.findAll();
     }

--- a/src/main/java/org/server/remoteclass/service/UserServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/UserServiceImpl.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.Optional;
 
 @Service
@@ -31,13 +32,14 @@ public class UserServiceImpl implements UserService{
     //현재 스프링 시큐리티 컨텍스트에 있는 유저 반환
     @Transactional(readOnly = true)
     @Override
-    public Optional<User> getMyUserWithAuthorities(){
-        return SecurityUtil.getCurrentUserEmail().flatMap(userRepository::findByEmail);
+    public UserDto getMyUserWithAuthorities(){
+        return UserDto.from(SecurityUtil.getCurrentUserEmail().flatMap(userRepository::findByEmail).orElse(null));
     }
 
     @Transactional(readOnly = true)
     @Override
-    public Iterable<User> getUsersByAll(){
+    public Iterable<UserDto> getUsersByAll(){
+        Iterable<UserDto> userDtoIterable = userRepository.findAll().stream().map(user -> model)
         return userRepository.findAll();
     }
 

--- a/src/main/java/org/server/remoteclass/service/UserServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/UserServiceImpl.java
@@ -25,14 +25,14 @@ public class UserServiceImpl implements UserService{
     @Transactional(readOnly = true)
     @Override
     public UserDto getUserWithAuthorities(String email){
-        return UserDto.from(userRepository.findOneWithAuthoritiesByEmail(email).orElse(null));
+        return UserDto.from(userRepository.findByEmail(email).orElse(null));
     }
 
-
+    //현재 스프링 시큐리티 컨텍스트에 있는 유저 반환
     @Transactional(readOnly = true)
     @Override
     public Optional<User> getMyUserWithAuthorities(){
-        return SecurityUtil.getCurrentUserEmail().flatMap(userRepository::findOneWithAuthoritiesByEmail);
+        return SecurityUtil.getCurrentUserEmail().flatMap(userRepository::findByEmail);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/server/remoteclass/util/BeanConfiguration.java
+++ b/src/main/java/org/server/remoteclass/util/BeanConfiguration.java
@@ -1,0 +1,14 @@
+package org.server.remoteclass.util;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class BeanConfiguration {
+
+    @Bean
+    public ModelMapper modelMapper(){
+        return new ModelMapper();
+    }
+}

--- a/src/main/java/org/server/remoteclass/util/BeanConfiguration.java
+++ b/src/main/java/org/server/remoteclass/util/BeanConfiguration.java
@@ -1,17 +1,19 @@
 package org.server.remoteclass.util;
 
 import org.modelmapper.ModelMapper;
+import org.modelmapper.convention.MatchingStrategies;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 
-// 만들었는데 현재는 잘 작동하지 않네요. 추후 수정하겠습니다.
 @Configuration
 public class BeanConfiguration {
 
     @Bean
     public ModelMapper modelMapper(){
-        return new ModelMapper();
+        ModelMapper mapper = new ModelMapper();
+        mapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
+        return mapper;
     }
 
 }

--- a/src/main/java/org/server/remoteclass/util/BeanConfiguration.java
+++ b/src/main/java/org/server/remoteclass/util/BeanConfiguration.java
@@ -4,6 +4,8 @@ import org.modelmapper.ModelMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+
+// 만들었는데 현재는 잘 작동하지 않네요. 추후 수정하겠습니다.
 @Configuration
 public class BeanConfiguration {
 
@@ -11,4 +13,5 @@ public class BeanConfiguration {
     public ModelMapper modelMapper(){
         return new ModelMapper();
     }
+
 }

--- a/src/main/java/org/server/remoteclass/util/SecurityUtil.java
+++ b/src/main/java/org/server/remoteclass/util/SecurityUtil.java
@@ -5,9 +5,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
 
 import java.util.Optional;
 
+@Component
 public class SecurityUtil {
 
     private static final Logger logger = LoggerFactory.getLogger(SecurityUtil.class);


### PR DESCRIPTION
1) 반복될 수 있는 자료형을 Iterable로 모두 수정하였습니다.
2) 서비스->컨트롤러, 컨트롤러 단에서 Entity 형식의 반환형을 dto로 수정하였습니다.
2) 학생이 수강하는 강의 리스트의 반환형이 Student로 되어 있는 것을 LectureDto 형식으로 수정하였습니다.
3) 예외라고 보기 애매한 상황(수강생이 없는 강의 등)에 대해서 예외처리 대신 빈 값(null)을 반환하도록 수정하였습니다.
4. `@Transactional`을 맨 위에 선언하였고, 조회 함수가 많은 경우 readonly=true를, 그렇지 않은 경우는 어노테이션만 선언하였습니다.

기능 추가보다 기존 코드를 확실히 통일성 있게 해놔야 나중에 개발 할 때에 편할 것이라 생각하여 리팩토링과 약간의 버그 수정 작업을 진행하였습니다.