### PR TITLE
[REFACTOR] 쿼리 최적화 리팩토링 진행

### DIFF
--- a/src/main/java/org/server/remoteclass/dto/coupon/ResponseCouponDto.java
+++ b/src/main/java/org/server/remoteclass/dto/coupon/ResponseCouponDto.java
@@ -41,13 +41,19 @@ public class ResponseCouponDto {
                 .couponValidDays(coupon.getCouponValidDays())
                 .createdDate(coupon.getCreatedDate())
                 .issuedCouponList(coupon.getIssuedCouponList().stream()
-                        .map(issuedCoupon ->
-                                        new ResponseIssuedCouponDto(
-                                                issuedCoupon.getIssuedCouponId(),
-                                                issuedCoupon.isCouponUsed(),
-                                                issuedCoupon.getCoupon().getCouponCode(),
-                                                issuedCoupon.getCouponValidDate())
+                        .map(ResponseIssuedCouponDto::NotIncludeCoupon
                         ).collect(Collectors.toList()))
+                .build();
+    }
+
+    public static ResponseCouponDto notIncludeIssuedCoupons(Coupon coupon){
+        if(coupon == null) return null;
+        return ResponseCouponDto.builder()
+                .couponId(coupon.getCouponId())
+                .couponCode(coupon.getCouponCode())
+                .couponValid(coupon.isCouponValid())
+                .couponValidDays(coupon.getCouponValidDays())
+                .createdDate(coupon.getCreatedDate())
                 .build();
     }
 

--- a/src/main/java/org/server/remoteclass/dto/event/ResponseEventDto.java
+++ b/src/main/java/org/server/remoteclass/dto/event/ResponseEventDto.java
@@ -1,6 +1,7 @@
 package org.server.remoteclass.dto.event;
 
 import lombok.*;
+import org.server.remoteclass.dto.coupon.ResponseCouponDto;
 import org.server.remoteclass.entity.Event;
 
 import java.time.LocalDateTime;
@@ -13,7 +14,7 @@ import java.time.LocalDateTime;
 public class ResponseEventDto {
 
     private Long eventId;
-    private Long couponId;
+    private ResponseCouponDto coupon;
     private String title;
     private LocalDateTime eventStartDate;
     private LocalDateTime eventEndDate;
@@ -23,7 +24,7 @@ public class ResponseEventDto {
         if(event == null) return null;
         return ResponseEventDto.builder()
                 .eventId(event.getEventId())
-                .couponId(event.getCoupon().getCouponId())
+                .coupon(ResponseCouponDto.notIncludeIssuedCoupons(event.getCoupon()))
                 .title(event.getTitle())
                 .eventStartDate(event.getEventStartDate())
                 .eventEndDate(event.getEventEndDate())

--- a/src/main/java/org/server/remoteclass/dto/issuedcoupon/ResponseIssuedCouponDto.java
+++ b/src/main/java/org/server/remoteclass/dto/issuedcoupon/ResponseIssuedCouponDto.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import org.server.remoteclass.dto.coupon.ResponseCouponDto;
 import org.server.remoteclass.entity.IssuedCoupon;
 
 import java.time.LocalDateTime;
@@ -17,7 +18,7 @@ public class ResponseIssuedCouponDto {
 
     private Long issuedCouponId;
     private Boolean couponUsed;
-    private String couponCode;
+    private ResponseCouponDto coupon;
     private LocalDateTime couponValidDate; // 쿠폰 유효기간이라 봐주시면 됩니다.
 
     public ResponseIssuedCouponDto(){
@@ -27,10 +28,19 @@ public class ResponseIssuedCouponDto {
         if(issuedCoupon == null) return null;
         return ResponseIssuedCouponDto.builder()
                 .issuedCouponId(issuedCoupon.getIssuedCouponId())
-                .couponCode(issuedCoupon.getCoupon().getCouponCode())
+                .coupon(ResponseCouponDto.notIncludeIssuedCoupons(issuedCoupon.getCoupon()))
                 .couponUsed(issuedCoupon.isCouponUsed())
                 .couponValidDate(issuedCoupon.getCouponValidDate())
                 .build();
         // 쿠폰 종류를 식별할 수 있는 컬럼 필요.
+    }
+
+    public static ResponseIssuedCouponDto NotIncludeCoupon(IssuedCoupon issuedCoupon){
+        if(issuedCoupon == null) return null;
+        return ResponseIssuedCouponDto.builder()
+                .issuedCouponId(issuedCoupon.getIssuedCouponId())
+                .couponUsed(issuedCoupon.isCouponUsed())
+                .couponValidDate(issuedCoupon.getCouponValidDate())
+                .build();
     }
 }

--- a/src/main/java/org/server/remoteclass/dto/lecture/ResponseLectureDto.java
+++ b/src/main/java/org/server/remoteclass/dto/lecture/ResponseLectureDto.java
@@ -18,7 +18,9 @@ public class ResponseLectureDto {
     private LocalDateTime startDate;
     private LocalDateTime endDate;
     private Long categoryId;
+    private String categoryName;
     private Long lecturer;
+    private String lecturerName;
 
     public static ResponseLectureDto from(Lecture lecture){
         if(lecture == null) return null;
@@ -30,7 +32,9 @@ public class ResponseLectureDto {
                 .startDate(LocalDateTime.from(lecture.getStartDate()))
                 .endDate(LocalDateTime.from(lecture.getEndDate()))
                 .categoryId(lecture.getCategory().getCategoryId())
+                .categoryName(lecture.getCategory().getCategoryName())
                 .lecturer(lecture.getUser().getUserId())
+                .lecturerName(lecture.getUser().getName())
                 .build();
     }
 }

--- a/src/main/java/org/server/remoteclass/dto/lecture/ResponseLectureFromStudentDto.java
+++ b/src/main/java/org/server/remoteclass/dto/lecture/ResponseLectureFromStudentDto.java
@@ -19,8 +19,8 @@ public class ResponseLectureFromStudentDto {
     private Integer price;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
-    private Long categoryId;
-    private Long lecturer;
+    private String categoryId;
+    private String lecturer;
 
     public ResponseLectureFromStudentDto(Student student) {
         this.lectureId = student.getLecture().getLectureId();
@@ -29,8 +29,8 @@ public class ResponseLectureFromStudentDto {
         this.price = student.getLecture().getPrice();
         this.startDate = student.getLecture().getStartDate();
         this.endDate = student.getLecture().getEndDate();
-        this.categoryId = student.getLecture().getCategory().getCategoryId();
-        this.lecturer = student.getLecture().getUser().getUserId();
+        this.categoryId = student.getLecture().getCategory().getCategoryName();
+        this.lecturer = student.getLecture().getUser().getName();
     }
 
     public static ResponseLectureFromStudentDto from(Student student) {
@@ -42,8 +42,8 @@ public class ResponseLectureFromStudentDto {
                 .price(student.getLecture().getPrice())
                 .startDate(LocalDateTime.from(student.getLecture().getStartDate()))
                 .endDate(LocalDateTime.from(student.getLecture().getEndDate()))
-                .categoryId(student.getLecture().getCategory().getCategoryId())
-                .lecturer(student.getLecture().getUser().getUserId())
+                .categoryId(student.getLecture().getCategory().getCategoryName())
+                .lecturer(student.getLecture().getUser().getName())
                 .build();
     }
 }

--- a/src/main/java/org/server/remoteclass/dto/lecture/ResponseLectureFromStudentDto.java
+++ b/src/main/java/org/server/remoteclass/dto/lecture/ResponseLectureFromStudentDto.java
@@ -19,7 +19,7 @@ public class ResponseLectureFromStudentDto {
     private Integer price;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
-    private String categoryId;
+    private String categoryName;
     private String lecturer;
 
     public ResponseLectureFromStudentDto(Student student) {
@@ -29,7 +29,7 @@ public class ResponseLectureFromStudentDto {
         this.price = student.getLecture().getPrice();
         this.startDate = student.getLecture().getStartDate();
         this.endDate = student.getLecture().getEndDate();
-        this.categoryId = student.getLecture().getCategory().getCategoryName();
+        this.categoryName = student.getLecture().getCategory().getCategoryName();
         this.lecturer = student.getLecture().getUser().getName();
     }
 
@@ -42,7 +42,7 @@ public class ResponseLectureFromStudentDto {
                 .price(student.getLecture().getPrice())
                 .startDate(LocalDateTime.from(student.getLecture().getStartDate()))
                 .endDate(LocalDateTime.from(student.getLecture().getEndDate()))
-                .categoryId(student.getLecture().getCategory().getCategoryName())
+                .categoryName(student.getLecture().getCategory().getCategoryName())
                 .lecturer(student.getLecture().getUser().getName())
                 .build();
     }

--- a/src/main/java/org/server/remoteclass/dto/order/ResponseOrderDto.java
+++ b/src/main/java/org/server/remoteclass/dto/order/ResponseOrderDto.java
@@ -28,6 +28,7 @@ public class ResponseOrderDto {
     private String bank;  //입금은행
     private String account;  //예금주
     private Long issuedCouponId;       //적용하는 쿠폰 아이디
+    private String issuedCouponName;
     private Integer originalPrice;
     private Integer salePrice;
 
@@ -45,6 +46,7 @@ public class ResponseOrderDto {
         }
         else {
             this.issuedCouponId = order.getIssuedCoupon().getIssuedCouponId();
+            this.issuedCouponName = order.getIssuedCoupon().getCoupon().getTitle();
             this.salePrice = order.getSalePrice();
         }
         this.originalPrice = order.getOriginalPrice();

--- a/src/main/java/org/server/remoteclass/jpa/CartRepository.java
+++ b/src/main/java/org/server/remoteclass/jpa/CartRepository.java
@@ -9,6 +9,10 @@ import java.util.List;
 public interface CartRepository extends JpaRepository<Cart, Long> {
 
     //수강생 별 장바구니에 넣은 강좌 리스트 최근순으로
+    @Query("select c from Cart c " +
+            "join fetch c.lecture l " +
+            "join fetch l.user " +
+            "where c.user.userId=:userId")
     List<Cart> findByUser_UserIdOrderByCreatedDateDesc(Long userId);
     //수강생이 강좌를 수강했었는지 여부
     boolean existsByLecture_LectureIdAndUser_UserId(Long lectureId, Long userId);
@@ -18,10 +22,13 @@ public interface CartRepository extends JpaRepository<Cart, Long> {
     void deleteAllByUser_UserId(Long userId);
     boolean existsByUser_UserId(Long userId);
 
-    @Query("SELECT SUM(l.price) from Cart c, Lecture l where c.lecture.lectureId= l.lectureId and c.user.userId= :userId")
+    @Query("select sum(l.price) from Cart c " +
+            "join c.lecture l " +
+            "where c.user.userId=:userId")
     int findSumCartByUserId(Long userId);
 
-    @Query("SELECT COUNT(c) from Cart c where c.user.userId= :userId")
+    @Query("select count(c) from Cart c " +
+            "where c.user.userId=:userId")
     int findCountCartByUserId(Long userId);
 
 }

--- a/src/main/java/org/server/remoteclass/jpa/EventRepository.java
+++ b/src/main/java/org/server/remoteclass/jpa/EventRepository.java
@@ -2,11 +2,20 @@ package org.server.remoteclass.jpa;
 
 import org.server.remoteclass.entity.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
 
+    @Query("select e from Event e " +
+            "join fetch e.coupon ")
+    List<Event> findAll();
+
+    @Query("select e from Event e " +
+            "join fetch e.coupon " +
+            "where e.eventId=:eventId")
     Optional<Event> findByEventId(Long eventId);
     void deleteByEventId(Long eventId);
 }

--- a/src/main/java/org/server/remoteclass/jpa/IssuedCouponRepository.java
+++ b/src/main/java/org/server/remoteclass/jpa/IssuedCouponRepository.java
@@ -12,9 +12,14 @@ public interface IssuedCouponRepository extends JpaRepository<IssuedCoupon, Long
     IssuedCoupon findByIssuedCouponId(Long issuedCouponId);
 
     // 내가 가지고 있는 쿠폰 조회 기능
-    @Query("SELECT m FROM IssuedCoupon m where m.user.userId = :userId")
+    @Query("select i from IssuedCoupon i " +
+            "join fetch i.coupon " +
+            "where i.user.userId=:userId")
     List<IssuedCoupon> findByUser(@Param("userId") Long userId);
-    // 쿠폰 발급번호로 쿠폰 찾기
-    @Query("SELECT m FROM IssuedCoupon m where m.user.userId = :userId and m.issuedCouponId = :issuedCouponId")
+
+    // 쿠폰 발급번호와 사용자 아이디로 쿠폰 찾기
+    @Query("select i from IssuedCoupon i " +
+            "join fetch i.coupon " +
+            "where i.user.userId=:userId and i.issuedCouponId = :issuedCouponId")
     Optional<IssuedCoupon> findByUserAndIssuedCouponId(@Param("userId") Long userId, @Param("issuedCouponId") Long issuedCouponId);
 }

--- a/src/main/java/org/server/remoteclass/jpa/LectureRepository.java
+++ b/src/main/java/org/server/remoteclass/jpa/LectureRepository.java
@@ -2,12 +2,29 @@ package org.server.remoteclass.jpa;
 
 import org.server.remoteclass.entity.Lecture;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface LectureRepository extends JpaRepository<Lecture, Long>{
 
+    @Query("select l from Lecture l " +
+            "join fetch l.category " +
+            "join fetch l.user " +
+            "where l.lectureId=:lectureId")
+    Optional<Lecture> findById(Long lectureId);
+
     //카테고리별 강의 조회
+    @Query("select l from Lecture l " +
+            "join fetch l.category " +
+            "join fetch l.user " +
+            "where l.category.categoryId=:categoryId")
     List<Lecture> findByCategory_CategoryId(Long categoryId);
+
+    @Query("select l from Lecture l " +
+            "join fetch l.category " +
+            "join fetch l.user")
+    List<Lecture> findAll();
 
 }

--- a/src/main/java/org/server/remoteclass/jpa/OrderRepository.java
+++ b/src/main/java/org/server/remoteclass/jpa/OrderRepository.java
@@ -10,15 +10,19 @@ import java.util.List;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
-    //주문 전체 목록
-    List<Order> findAll();
-
     // 회원이 주문한 주문 목록 최신순으로
+    @Query("select o from Order o " +
+            "join fetch o.issuedCoupon i " +
+            "join fetch i.coupon c " +
+            "where o.user.userId=:userId " +
+            "order by o.orderDate desc ")
     List<Order> findByUser_UserIdOrderByOrderDateDesc(Long userId);
 
     List<Order> findByOrderByOrderDateDesc();
 
-    @Query("SELECT SUM(l.price) from OrderLecture o, Lecture l where o.lecture.lectureId= l.lectureId and o.order.orderId= :orderId")
+    @Query("select sum(l.price) from OrderLecture o " +
+            "join o.lecture l " +
+            "where o.order.orderId=:orderId")
     Integer findSumOrderByOrderId(Long orderId);
 
 }

--- a/src/main/java/org/server/remoteclass/jpa/PurchaseRepository.java
+++ b/src/main/java/org/server/remoteclass/jpa/PurchaseRepository.java
@@ -1,13 +1,23 @@
 package org.server.remoteclass.jpa;
 
-import org.server.remoteclass.constant.Authority;
 import org.server.remoteclass.entity.Purchase;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PurchaseRepository extends JpaRepository<Purchase, Long> {
-//    @Query("select p from Purchase p where p.order.user.userId = ?1 order by p.purchaseDate DESC")
+
+    @Query("select p from Purchase p " +
+            "join fetch p.order o " +
+            "where o.user.userId=:userId " +
+            "order by p.purchaseDate desc")
     List<Purchase> findByOrder_User_UserIdOrderByPurchaseDateDesc(Long userId);
+
+    @Query("select p from Purchase p " +
+            "join fetch p.order " +
+            "where p.purchaseId=:purchaseId")
+    Optional<Purchase> findById(Long purchaseId);
+
 }

--- a/src/main/java/org/server/remoteclass/jpa/StudentRepository.java
+++ b/src/main/java/org/server/remoteclass/jpa/StudentRepository.java
@@ -2,14 +2,24 @@ package org.server.remoteclass.jpa;
 
 import org.server.remoteclass.entity.Student;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface StudentRepository extends JpaRepository<Student, Long> {
 
     // 강좌별 수강생 전체 리스트
+    @Query("select s from Student s " +
+            "join fetch s.user " +
+            "where s.lecture.lectureId=:lectureId")
     List<Student> findByLecture_LectureId(Long lectureId);
     //수강생 별 수강강좌 리스트
+    @Query("select s from Student s " +
+            "join fetch s.lecture l " +
+            "join fetch l.user " +
+            "join fetch l.category " +
+            "where s.user.userId=:userId " +
+            "order by l.startDate desc")
     List<Student> findByUser_UserIdOrderByLecture_StartDateDesc(Long userId);
     //수강생이 강좌를 수강했었는지 여부
     boolean existsByLecture_LectureIdAndUser_UserId(Long lectureId, Long userId);

--- a/src/main/java/org/server/remoteclass/service/issuedCoupon/IssuedCouponServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/issuedCoupon/IssuedCouponServiceImpl.java
@@ -74,8 +74,7 @@ public class IssuedCouponServiceImpl implements IssuedCouponService{
 
         List<IssuedCoupon> issuedCouponList = issuedCouponRepository.findByUser(user.getUserId());
         return issuedCouponList.stream()
-                .map(issuedCoupon ->
-                        ResponseIssuedCouponDto.from(issuedCoupon)
+                .map(ResponseIssuedCouponDto::from
                 ).collect(Collectors.toList());
     }
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,6 +13,7 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
+        default_batch_fetch_size: 100
         format_sql: true
     database: mysql
     generate-ddl: true

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,7 +13,7 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
-        format-sql: true
+        format_sql: true
     database: mysql
     generate-ddl: true
     show-sql: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,7 +12,7 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
-        format-sql: true
+        format_sql: true
     database: mysql
     generate-ddl: true
     show-sql: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,6 +12,7 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
+        default_batch_fetch_size: 100
         format_sql: true
     database: mysql
     generate-ddl: true

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -10,6 +10,7 @@ spring:
       ddl-auto: create-drop
     properties:
       hibernate:
+        default_batch_fetch_size: 100
         format_sql: true
     defer-datasource-initialization: true
   h2:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -10,7 +10,7 @@ spring:
       ddl-auto: create-drop
     properties:
       hibernate:
-        format-sql: true
+        format_sql: true
     defer-datasource-initialization: true
   h2:
     console:


### PR DESCRIPTION
지연로딩에 의해 발생하는 `N+1 문제` 와 같은 이슈를 해결하기 위해 다음과 같은 쿼리 최적화를 진행했습니다 :)

- 연관 엔티티 호출 쿼리 수 단축
- 컬렉션 조인시 쿼리 수 단축
- DTO 목적상 필요한 데이터 추가 및 양방향 관계에 의해 불필요한 데이터 로딩을 막기 위한 빌더 추가
    - 예) 전체 수강 강좌수 목록 조회에서 단순 강의자의 id 노출 본단 강사의 이름을 아는게 클라이언트 입장에선 더 중요
    - 단, Admin을 위한 DTO에선 id로 처리(id 값으로 자체적으로 모든 데이터의 조회가 가능하기 때문, 반면 원격 서비스 이용자는 그런 권한이 없음)  
    - 지연 로딩 설정으로 인해 발생하는 불필요한 데이터 조회 방지
    
- repository 인터페이스에 불필요한 메서드 제거
- 복수의 테이블에서 where 이용한 집계(sum)쿼리 -> `join`으로 변경

