### PR TITLE
[FEAT] 기한 만료된 엑세스 토큰과 유효한 리프레쉬 토큰이 들어온 경우 토큰 재발급 서비스 응답 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ dependencies {
 	implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
 	implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
 
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/server/remoteclass/dto/auth/RequestTokenDto.java
+++ b/src/main/java/org/server/remoteclass/dto/auth/RequestTokenDto.java
@@ -1,5 +1,6 @@
 package org.server.remoteclass.dto.auth;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -9,6 +10,7 @@ import javax.validation.constraints.NotEmpty;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
 public class RequestTokenDto {
     @NotEmpty
     private String accessToken;

--- a/src/main/java/org/server/remoteclass/entity/Token.java
+++ b/src/main/java/org/server/remoteclass/entity/Token.java
@@ -13,25 +13,29 @@ import javax.persistence.Table;
 @Entity
 @Data
 @NoArgsConstructor
-@Table(name = "refresh_token")
-public class RefreshToken {
+public class Token {
 
     @Id
     @Column(name = "key_name") // key가 예약어라 테이블 자동 생성이 안되서 key_name으로 변경
     private String key;
 //    private Long key;
 
-    @Column(name="value")
-    private String value;
+    @Column(name = "access_token")
+    private String accessToken;
 
-    public RefreshToken updateValue(String token){
-        this.value = token;
+    @Column(name="refresh_token")
+    private String refreshToken;
+
+    public Token updateValue(String accessToken, String refreshToken){
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
         return this;
     }
 
     @Builder
-    public RefreshToken(String key, String value){
+    public Token(String key, String accessToken, String refreshToken){
         this.key = key;
-        this.value = value;
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
     }
 }

--- a/src/main/java/org/server/remoteclass/exception/ApiError.java
+++ b/src/main/java/org/server/remoteclass/exception/ApiError.java
@@ -1,0 +1,57 @@
+package org.server.remoteclass.exception;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+public class ApiError {
+
+    private HttpStatus status;
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy hh:mm:ss")
+    private LocalDateTime timestamp;
+    private String message;
+    private String debugMessage;
+
+    private ApiError() {
+        timestamp = LocalDateTime.now();
+    }
+    public ApiError(HttpStatus status) {
+        this();
+        this.status = status;
+    }
+
+    public ApiError(HttpStatus status, Throwable ex) {
+        this();
+        this.status = status;
+        this.message = "Unexpected error";
+        this.debugMessage = ex.getLocalizedMessage();
+    }
+
+    public ApiError(HttpStatus status, String message, Throwable ex) {
+        this();
+        this.status = status;
+        this.message = message;
+        this.debugMessage = ex.getLocalizedMessage();
+    }
+
+    public String convertToJson() throws JsonProcessingException {
+        if (this == null) {
+            return null;
+        }
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        return mapper.writeValueAsString(this);
+    }
+
+    //Setters and getters
+}

--- a/src/main/java/org/server/remoteclass/exception/ExceptionHandlerFilter.java
+++ b/src/main/java/org/server/remoteclass/exception/ExceptionHandlerFilter.java
@@ -1,0 +1,45 @@
+package org.server.remoteclass.exception;
+
+import io.jsonwebtoken.JwtException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class ExceptionHandlerFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try{
+            filterChain.doFilter(request,response);
+        }
+        catch (JwtException e){
+            setErrorResponse(HttpStatus.BAD_REQUEST, response, e);
+        }
+        catch (RuntimeException ex){
+            log.error("runtime exception exception handler filter");
+            setErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR,response,ex);
+        }
+    }
+
+    public void setErrorResponse(HttpStatus status, HttpServletResponse response, Throwable ex){
+        response.setStatus(status.value());
+        response.setContentType("application/json");
+        // A class used for errors
+        ApiError apiError = new ApiError(status, ex);
+        try {
+            String json = apiError.convertToJson();
+            System.out.println(json);
+            response.getWriter().write(json);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/org/server/remoteclass/jpa/RefreshTokenRepository.java
+++ b/src/main/java/org/server/remoteclass/jpa/RefreshTokenRepository.java
@@ -1,10 +1,10 @@
 package org.server.remoteclass.jpa;
 
-import org.server.remoteclass.entity.RefreshToken;
+import org.server.remoteclass.entity.Token;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
-    Optional<RefreshToken> findByKey(String key);
+public interface RefreshTokenRepository extends JpaRepository<Token, Long> {
+    Optional<Token> findByKey(String key);
 }

--- a/src/main/java/org/server/remoteclass/jwt/JwtFilter.java
+++ b/src/main/java/org/server/remoteclass/jwt/JwtFilter.java
@@ -1,5 +1,11 @@
 package org.server.remoteclass.jwt;
 
+import org.server.remoteclass.dto.auth.RequestTokenDto;
+import org.server.remoteclass.dto.auth.ResponseTokenDto;
+import org.server.remoteclass.exception.BadRequestArgumentException;
+import org.server.remoteclass.exception.ErrorCode;
+import org.server.remoteclass.exception.ForbiddenException;
+import org.server.remoteclass.service.auth.AuthService;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -11,6 +17,7 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 public class JwtFilter extends GenericFilterBean {
@@ -19,32 +26,70 @@ public class JwtFilter extends GenericFilterBean {
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String BEARER_PREFIX = "Bearer ";
 
-    private TokenProvider tokenProvider;
+    // 요청 시에 들어올 Refresh Token의 Key값
+    public static final String REFRESH_TOKEN_HEADER = "Refresh";
 
-    public JwtFilter(TokenProvider tokenProvider) {
+    private final TokenProvider tokenProvider;
+    private final AuthService authService;
+
+    public JwtFilter(TokenProvider tokenProvider, AuthService authService) {
         this.tokenProvider = tokenProvider;
+        this.authService = authService;
     }
 
     // 실제 필터링 로직은 doFilter에서 함
-    // JWT 토큰의 인증 정보를 현재 쓰레드의 SecurityContext에 저장하는 역할 수행행
-   @Override
-    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException{
+    // JWT 토큰의 인증 정보를 현재 쓰레드의 SecurityContext에 저장하는 역할 수행
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws ServletException, IOException {
         HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
         String jwt = resolveToken(httpServletRequest);
+        String jwt2 = resolveRefreshToken(httpServletRequest);
         String requestURI = httpServletRequest.getRequestURI();
 
-        if(StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)){
+        if(StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt) == 1){
             Authentication authentication = tokenProvider.getAuthentication(jwt);
             SecurityContextHolder.getContext().setAuthentication(authentication);
             logger.debug("Security Context에 `{}` 인증 정보를 저장했습니다, uri: {}", authentication.getName(), requestURI);
-        } else{
-            logger.debug("유효한 JWT 토큰이 없습니다. uri {}", requestURI);
+            filterChain.doFilter(servletRequest, servletResponse);
         }
-        filterChain.doFilter(servletRequest, servletResponse);
+
+        else if(StringUtils.hasText(jwt) && StringUtils.hasText(jwt2) &&
+            tokenProvider.validateToken(jwt) == -1 && tokenProvider.validateToken(jwt2) == 1){
+
+            HttpServletResponse httpServletResponse = (HttpServletResponse) servletResponse;
+            ResponseTokenDto responseTokenDto = authService.reissue(new RequestTokenDto(jwt, jwt2));
+            httpServletResponse.addHeader("grantType", "bearer");
+            httpServletResponse.addHeader("accessToken", responseTokenDto.getAccessToken());
+            httpServletResponse.addHeader("refreshToken", responseTokenDto.getRefreshToken());
+            //헤더에는 Long 타입을 담을 수 없어 String으로 변환하였습니다.
+            httpServletResponse.addHeader("accessTokenExpireDate", responseTokenDto.getAccessTokenExpireDate().toString());
+            // 다음 단계로 진입시켜주는 함수
+            Authentication authentication = tokenProvider.getAuthentication(jwt);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            logger.debug("Security Context에 `{}` 인증 정보를 저장했습니다, uri: {}", authentication.getName(), requestURI);
+            filterChain.doFilter(servletRequest, servletResponse);
+            RequestTokenDto requestTokenDto = new RequestTokenDto();
+            requestTokenDto.setAccessToken(responseTokenDto.getAccessToken());
+            requestTokenDto.setRefreshToken(responseTokenDto.getRefreshToken());
+            authService.updateToken(requestTokenDto);
+        }
+
+        else{
+            logger.debug("유효한 JWT 토큰이 없습니다. uri {}", requestURI);
+            filterChain.doFilter(servletRequest, servletResponse);
+        }
     }
 
     private String resolveToken(HttpServletRequest request){
         String bearToken = request.getHeader(AUTHORIZATION_HEADER);
+        if(StringUtils.hasText(bearToken) && bearToken.startsWith(BEARER_PREFIX)){
+            return bearToken.substring(7);
+        }
+        return null;
+    }
+
+    private String resolveRefreshToken(HttpServletRequest request){
+        String bearToken = request.getHeader(REFRESH_TOKEN_HEADER);
         if(StringUtils.hasText(bearToken) && bearToken.startsWith(BEARER_PREFIX)){
             return bearToken.substring(7);
         }

--- a/src/main/java/org/server/remoteclass/jwt/JwtSecurityConfig.java
+++ b/src/main/java/org/server/remoteclass/jwt/JwtSecurityConfig.java
@@ -1,5 +1,6 @@
 package org.server.remoteclass.jwt;
 
+import org.server.remoteclass.service.auth.AuthService;
 import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.DefaultSecurityFilterChain;
@@ -8,13 +9,15 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
 
     private TokenProvider tokenProvider;
-    public JwtSecurityConfig(TokenProvider tokenProvider){
+    private AuthService authService;
+    public JwtSecurityConfig(TokenProvider tokenProvider, AuthService authService){
         this.tokenProvider = tokenProvider;
+        this.authService = authService;
     }
 
     @Override
     public void configure(HttpSecurity http){
-        JwtFilter customFilter = new JwtFilter(tokenProvider);
+        JwtFilter customFilter = new JwtFilter(tokenProvider, authService);
         http.addFilterBefore(customFilter, UsernamePasswordAuthenticationFilter.class);
     }
 

--- a/src/main/java/org/server/remoteclass/jwt/JwtSecurityConfig.java
+++ b/src/main/java/org/server/remoteclass/jwt/JwtSecurityConfig.java
@@ -1,6 +1,8 @@
 package org.server.remoteclass.jwt;
 
+import org.server.remoteclass.exception.ExceptionHandlerFilter;
 import org.server.remoteclass.service.auth.AuthService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.DefaultSecurityFilterChain;
@@ -15,10 +17,15 @@ public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurity
         this.authService = authService;
     }
 
+    @Autowired
+    private ExceptionHandlerFilter exceptionHandlerFilter;
+
     @Override
     public void configure(HttpSecurity http){
         JwtFilter customFilter = new JwtFilter(tokenProvider, authService);
         http.addFilterBefore(customFilter, UsernamePasswordAuthenticationFilter.class);
+//        JwtFilter 예외처리 부분에서 작성한 코드이며, 현재 주석 처리하면 에러 뜹니다.
+//        http.addFilterBefore(exceptionHandlerFilter, JwtFilter.class);
     }
 
 }

--- a/src/main/java/org/server/remoteclass/jwt/TokenProvider.java
+++ b/src/main/java/org/server/remoteclass/jwt/TokenProvider.java
@@ -90,20 +90,22 @@ public class TokenProvider implements InitializingBean {
         return new UsernamePasswordAuthenticationToken(principal, token, authorities);
     }
 
-    public boolean validateToken(String token){
+    // 이 부분도 ExceptionHandler로 추후에 처리하기
+    public int validateToken(String token){
         try{
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
-            return true;
+            return 1;
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e){
             logger.info("잘못된 JWT 서명입니다.");
         } catch (ExpiredJwtException e){
             logger.info("만료된 JWT 토큰입니다.");
+            return -1;
         } catch (UnsupportedJwtException e){
             logger.info("지원되지 않는 JWT 토큰입니다.");
         } catch (IllegalArgumentException e){
             logger.info("JWT 토큰이 잘못되었습니다.");
         }
-        return false;
+        return 0;
     }
 
     private Claims parseClaims(String accessToken){

--- a/src/main/java/org/server/remoteclass/security/WebSecurity.java
+++ b/src/main/java/org/server/remoteclass/security/WebSecurity.java
@@ -4,6 +4,7 @@ import org.server.remoteclass.jwt.JwtAccessDeniedHandler;
 import org.server.remoteclass.jwt.JwtAuthenticationEntryPoint;
 import org.server.remoteclass.jwt.JwtSecurityConfig;
 import org.server.remoteclass.jwt.TokenProvider;
+import org.server.remoteclass.service.auth.AuthService;
 import org.server.remoteclass.service.user.UserService;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
@@ -24,6 +25,7 @@ public class WebSecurity extends WebSecurityConfigurerAdapter {
     private final UserService userService;
 
     private final TokenProvider tokenProvider;
+    private final AuthService authService;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
@@ -33,7 +35,8 @@ public class WebSecurity extends WebSecurityConfigurerAdapter {
             UserService userService,
             TokenProvider tokenProvider,
             JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint,
-            JwtAccessDeniedHandler jwtAccessDeniedHandler
+            JwtAccessDeniedHandler jwtAccessDeniedHandler,
+            AuthService authService
     ){
         this.bCryptPasswordEncoder = bCryptPasswordEncoder;
         this.env = env;
@@ -41,6 +44,7 @@ public class WebSecurity extends WebSecurityConfigurerAdapter {
         this.userService = userService;
         this.jwtAuthenticationEntryPoint = jwtAuthenticationEntryPoint;
         this.jwtAccessDeniedHandler = jwtAccessDeniedHandler;
+        this.authService = authService;
     }
 
     @Override
@@ -78,6 +82,6 @@ public class WebSecurity extends WebSecurityConfigurerAdapter {
                 .antMatchers("/reissue").permitAll()
                 .anyRequest().authenticated()
                 .and()
-                .apply(new JwtSecurityConfig(tokenProvider));
+                .apply(new JwtSecurityConfig(tokenProvider, authService));
     }
 }

--- a/src/main/java/org/server/remoteclass/service/auth/AuthService.java
+++ b/src/main/java/org/server/remoteclass/service/auth/AuthService.java
@@ -10,4 +10,6 @@ public interface AuthService {
     ResponseUserDto signup(RequestUserDto requestUserDto);
     ResponseTokenDto login(LoginDto loginDto);
     ResponseTokenDto reissue(RequestTokenDto requestTokenDto);
+    // 재발급한 토큰을 DB에 업데이트한다.
+    void updateToken(RequestTokenDto requestTokenDto);
 }

--- a/src/main/java/org/server/remoteclass/service/auth/AuthServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/auth/AuthServiceImpl.java
@@ -97,7 +97,7 @@ public class AuthServiceImpl implements AuthService{
                 .orElseThrow(() -> new ForbiddenException("로그아웃 된 사용자입니다.", ErrorCode.FORBIDDEN));
         // 4. Refresh Token 일치하는 지 검사
         if(!refreshToken.getValue().equals(requestTokenDto.getRefreshToken())){
-            throw new BadRequestArgumentException("토큰의 유저 정보가 일치하지 않습니다.", ErrorCode.BAD_REQUEST_ARGUMENT);
+            throw new BadRequestArgumentException("리프레쉬 토큰의 정보가 일치하지 않습니다.", ErrorCode.BAD_REQUEST_ARGUMENT);
         }
         // 5. 새로운 토큰 생성
         ResponseTokenDto responseTokenDto = tokenProvider.createToken(authentication);

--- a/src/main/java/org/server/remoteclass/service/event/EventServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/event/EventServiceImpl.java
@@ -76,6 +76,16 @@ public class EventServiceImpl implements EventService{
         eventRepository.deleteByEventId(eventId);
     }
 
+<<<<<<< HEAD
+=======
+    @Override
+    public void quitEvent(Long eventId) {
+        Event event = eventRepository.findByEventId(eventId).orElseThrow(() -> new IdNotExistException("존재하는 이벤트가 없습니다", ErrorCode.ID_NOT_EXIST));
+        event.getCoupon().setCouponValid(false);
+    }
+
+    // 현재 미구현 상태입니다.
+>>>>>>> f82f2f7 (feat: 유효기간 만료된 엑세스 토큰 & 유효한 리프레쉬 토큰으로 토큰 재발급 및 요청한 서비스 응답 기능 구현)
     @Transactional
     @Override
     public void quitEvent(){

--- a/src/main/java/org/server/remoteclass/service/event/EventServiceImpl.java
+++ b/src/main/java/org/server/remoteclass/service/event/EventServiceImpl.java
@@ -76,16 +76,8 @@ public class EventServiceImpl implements EventService{
         eventRepository.deleteByEventId(eventId);
     }
 
-<<<<<<< HEAD
-=======
-    @Override
-    public void quitEvent(Long eventId) {
-        Event event = eventRepository.findByEventId(eventId).orElseThrow(() -> new IdNotExistException("존재하는 이벤트가 없습니다", ErrorCode.ID_NOT_EXIST));
-        event.getCoupon().setCouponValid(false);
-    }
 
     // 현재 미구현 상태입니다.
->>>>>>> f82f2f7 (feat: 유효기간 만료된 엑세스 토큰 & 유효한 리프레쉬 토큰으로 토큰 재발급 및 요청한 서비스 응답 기능 구현)
     @Transactional
     @Override
     public void quitEvent(){


### PR DESCRIPTION
만료된 엑세스 토큰과 만료되지 않은 리프레쉬 토큰이 헤더에 함께 들어온 경우 토큰 재발급과 요청한 서비스를 제공하는 것을 한 번에 하는 기능을 구현하였습니다.
만료되지 않은 엑세스 토큰 & 만료되지 않은 리프레쉬 토큰의 경우 토큰 재발급이 일어나지 않습니다.

제가 테스트 시에는 잘 되어 풀 리퀘스트 올리지만, 안되는 지점 있으면 말씀해 주시면 바로 수정하겠습니다.

해결해야 할 것들 적겠습니다.
1. 에러 메시지가 저희가 구현한 형식대로 나오지 않습니다. [이 링크](https://samtao.tistory.com/48)에 제가 겪고 있는 현상과 매우 유사한 케이스기에 추후에 이것 보고 수정하겠습니다.
2. token.secret이 노출되어 있습니다. 기존의 어떤 평문을 암호화 했습니다. 평문을 다른 단어로 수정 및 gitignore화 시켜야 합니다.
3. 헤더에 토큰을 담아주다 보니 Long 타입을 넣어서 반환할 수 없어 기존의 Long 타입의 토큰 만료 시간 변수를 부득이하게 String으로 바꿨습니다. 로그인 경우와 통일하는 것도 고려중입니다.
4. 기존의 브랜치에서 토큰 관련 작업을 진행하다 브랜치를 옮겨 cherry-pick으로 커밋 내역을 따오는 과정에서 event 함수에서 quit 부분에서 조금 충돌이 있는데요. 이건 금방 해결할 수 있는 거라 머지 후에 빠르게 해결하겠습니다.
5. 현재 방식에서 토큰 재발급을 하게 되면 DB에는 유저 이메일과 refresh 토큰만 있습니다. jwt에서 유저 이메일을 추출하여 refresh 부분만 바꾸는 건데요. 그렇기에 과거의 만료된 엑세스 토큰(어차피 유저 정보는 시간이 지나도 추출해 낼 수 있으므로)과 새로 발급된 리프레쉬 토큰을 계속해서 사용하게 되면 토큰이 계속 발급됩니다. 이런 상황이 발생할까 싶긴 하지만, 더 나은 완성도를 위해서 DB에 엑세스 토큰도 같이 관리해서 매칭하는 작업을 진행 할 예정입니다.
6.  질문) 혹시 JwtFilter, JwtSecurityConfig, SecurytiUtil도 빈 등록을 해줘야 하나요?